### PR TITLE
[Feature/#12] 애플 로그인 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+# GoogleInfo
+GoogleService-Info.plist

--- a/ABloom/ABloom.xcodeproj/project.pbxproj
+++ b/ABloom/ABloom.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		3DB6A5A52AE0BDF800C1369F /* FirebaseRemoteConfigSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5A42AE0BDF800C1369F /* FirebaseRemoteConfigSwift */; };
 		3DB6A5A72AE0BDF800C1369F /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5A62AE0BDF800C1369F /* FirebaseStorage */; };
 		3DB6A5A92AE0BDF800C1369F /* FirebaseStorageCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5A82AE0BDF800C1369F /* FirebaseStorageCombine-Community */; };
+		3DB6A5AB2AE0C09800C1369F /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB6A5AA2AE0C09800C1369F /* LoginView.swift */; };
+		3DB6A5AE2AE0C12B00C1369F /* AppleLoginButtonViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB6A5AD2AE0C12B00C1369F /* AppleLoginButtonViewRepresentable.swift */; };
 		6053F15B2ADEB7700064A6E0 /* RegistrationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6053F15A2ADEB7700064A6E0 /* RegistrationViewModel.swift */; };
 		6053F15F2ADF6C3B0064A6E0 /* Ex+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6053F15E2ADF6C3B0064A6E0 /* Ex+View.swift */; };
 		6053F1622ADF6CDE0064A6E0 /* InputFieldModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6053F1612ADF6CDE0064A6E0 /* InputFieldModifier.swift */; };
@@ -59,6 +61,8 @@
 
 /* Begin PBXFileReference section */
 		3DB6A5712AE0BD7600C1369F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		3DB6A5AA2AE0C09800C1369F /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
+		3DB6A5AD2AE0C12B00C1369F /* AppleLoginButtonViewRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginButtonViewRepresentable.swift; sourceTree = "<group>"; };
 		6053F15A2ADEB7700064A6E0 /* RegistrationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationViewModel.swift; sourceTree = "<group>"; };
 		6053F15E2ADF6C3B0064A6E0 /* Ex+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ex+View.swift"; sourceTree = "<group>"; };
 		6053F1612ADF6CDE0064A6E0 /* InputFieldModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputFieldModifier.swift; sourceTree = "<group>"; };
@@ -126,6 +130,21 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3DB6A5AC2AE0C0B700C1369F /* Firebase */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Firebase;
+			sourceTree = "<group>";
+		};
+		3DB6A5AF2AE0C13800C1369F /* SubViews */ = {
+			isa = PBXGroup;
+			children = (
+				3DB6A5AD2AE0C12B00C1369F /* AppleLoginButtonViewRepresentable.swift */,
+			);
+			path = SubViews;
+			sourceTree = "<group>";
+		};
 		6053F1582ADEB7550064A6E0 /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -179,6 +198,8 @@
 			isa = PBXGroup;
 			children = (
 				AE2BB5FE2AD673890003CD85 /* LoginMD.md */,
+				3DB6A5AA2AE0C09800C1369F /* LoginView.swift */,
+				3DB6A5AF2AE0C13800C1369F /* SubViews */,
 			);
 			path = Login;
 			sourceTree = "<group>";
@@ -252,6 +273,7 @@
 				6053F1632ADF7F3D0064A6E0 /* Presentation */,
 				AE2BB6012AD674630003CD85 /* TabBar */,
 				AE2BB5F52AD66BF30003CD85 /* Login */,
+				3DB6A5AC2AE0C0B700C1369F /* Firebase */,
 				AE7EE4E62AD6409100E0A573 /* Preview Content */,
 			);
 			path = ABloom;
@@ -428,8 +450,10 @@
 				6055411A2ADE66B000AD5625 /* RegistrationView.swift in Sources */,
 				605541152ADE1A9D00AD5625 /* TabBarView.swift in Sources */,
 				AE7EE4E12AD6409000E0A573 /* ABloomApp.swift in Sources */,
+				3DB6A5AE2AE0C12B00C1369F /* AppleLoginButtonViewRepresentable.swift in Sources */,
 				6053F15F2ADF6C3B0064A6E0 /* Ex+View.swift in Sources */,
 				6053F1622ADF6CDE0064A6E0 /* InputFieldModifier.swift in Sources */,
+				3DB6A5AB2AE0C09800C1369F /* LoginView.swift in Sources */,
 				605541172ADE1ACF00AD5625 /* Tab.swift in Sources */,
 				AE8D3C5F2ADE3890009899A7 /* GradientColors.swift in Sources */,
 			);

--- a/ABloom/ABloom.xcodeproj/project.pbxproj
+++ b/ABloom/ABloom.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		3DB6A5A92AE0BDF800C1369F /* FirebaseStorageCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5A82AE0BDF800C1369F /* FirebaseStorageCombine-Community */; };
 		3DB6A5AB2AE0C09800C1369F /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB6A5AA2AE0C09800C1369F /* LoginView.swift */; };
 		3DB6A5AE2AE0C12B00C1369F /* AppleLoginButtonViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB6A5AD2AE0C12B00C1369F /* AppleLoginButtonViewRepresentable.swift */; };
+		3DB6A5B12AE11C2D00C1369F /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB6A5B02AE11C2D00C1369F /* LoginViewModel.swift */; };
+		3DB6A5B42AE11CCD00C1369F /* SignInAppleHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB6A5B32AE11CCD00C1369F /* SignInAppleHelper.swift */; };
 		6053F15B2ADEB7700064A6E0 /* RegistrationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6053F15A2ADEB7700064A6E0 /* RegistrationViewModel.swift */; };
 		6053F15F2ADF6C3B0064A6E0 /* Ex+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6053F15E2ADF6C3B0064A6E0 /* Ex+View.swift */; };
 		6053F1622ADF6CDE0064A6E0 /* InputFieldModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6053F1612ADF6CDE0064A6E0 /* InputFieldModifier.swift */; };
@@ -63,6 +65,9 @@
 		3DB6A5712AE0BD7600C1369F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		3DB6A5AA2AE0C09800C1369F /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		3DB6A5AD2AE0C12B00C1369F /* AppleLoginButtonViewRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginButtonViewRepresentable.swift; sourceTree = "<group>"; };
+		3DB6A5B02AE11C2D00C1369F /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
+		3DB6A5B32AE11CCD00C1369F /* SignInAppleHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInAppleHelper.swift; sourceTree = "<group>"; };
+		3DB6A5B52AE1278D00C1369F /* ABloom.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ABloom.entitlements; sourceTree = "<group>"; };
 		6053F15A2ADEB7700064A6E0 /* RegistrationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationViewModel.swift; sourceTree = "<group>"; };
 		6053F15E2ADF6C3B0064A6E0 /* Ex+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ex+View.swift"; sourceTree = "<group>"; };
 		6053F1612ADF6CDE0064A6E0 /* InputFieldModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputFieldModifier.swift; sourceTree = "<group>"; };
@@ -133,6 +138,7 @@
 		3DB6A5AC2AE0C0B700C1369F /* Firebase */ = {
 			isa = PBXGroup;
 			children = (
+				3DB6A5B22AE11CBA00C1369F /* Authentication */,
 			);
 			path = Firebase;
 			sourceTree = "<group>";
@@ -143,6 +149,14 @@
 				3DB6A5AD2AE0C12B00C1369F /* AppleLoginButtonViewRepresentable.swift */,
 			);
 			path = SubViews;
+			sourceTree = "<group>";
+		};
+		3DB6A5B22AE11CBA00C1369F /* Authentication */ = {
+			isa = PBXGroup;
+			children = (
+				3DB6A5B32AE11CCD00C1369F /* SignInAppleHelper.swift */,
+			);
+			path = Authentication;
 			sourceTree = "<group>";
 		};
 		6053F1582ADEB7550064A6E0 /* View */ = {
@@ -199,6 +213,7 @@
 			children = (
 				AE2BB5FE2AD673890003CD85 /* LoginMD.md */,
 				3DB6A5AA2AE0C09800C1369F /* LoginView.swift */,
+				3DB6A5B02AE11C2D00C1369F /* LoginViewModel.swift */,
 				3DB6A5AF2AE0C13800C1369F /* SubViews */,
 			);
 			path = Login;
@@ -259,6 +274,7 @@
 		AE7EE4DF2AD6409000E0A573 /* ABloom */ = {
 			isa = PBXGroup;
 			children = (
+				3DB6A5B52AE1278D00C1369F /* ABloom.entitlements */,
 				AE8D3C5D2ADE1A22009899A7 /* Info.plist */,
 				3DB6A5712AE0BD7600C1369F /* GoogleService-Info.plist */,
 				AE8D3C522ADE19F2009899A7 /* Fonts */,
@@ -450,9 +466,11 @@
 				6055411A2ADE66B000AD5625 /* RegistrationView.swift in Sources */,
 				605541152ADE1A9D00AD5625 /* TabBarView.swift in Sources */,
 				AE7EE4E12AD6409000E0A573 /* ABloomApp.swift in Sources */,
+				3DB6A5B12AE11C2D00C1369F /* LoginViewModel.swift in Sources */,
 				3DB6A5AE2AE0C12B00C1369F /* AppleLoginButtonViewRepresentable.swift in Sources */,
 				6053F15F2ADF6C3B0064A6E0 /* Ex+View.swift in Sources */,
 				6053F1622ADF6CDE0064A6E0 /* InputFieldModifier.swift in Sources */,
+				3DB6A5B42AE11CCD00C1369F /* SignInAppleHelper.swift in Sources */,
 				3DB6A5AB2AE0C09800C1369F /* LoginView.swift in Sources */,
 				605541172ADE1ACF00AD5625 /* Tab.swift in Sources */,
 				AE8D3C5F2ADE3890009899A7 /* GradientColors.swift in Sources */,
@@ -586,6 +604,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = ABloom/ABloom.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"ABloom/Preview Content\"";
@@ -617,6 +636,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = ABloom/ABloom.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"ABloom/Preview Content\"";

--- a/ABloom/ABloom.xcodeproj/project.pbxproj
+++ b/ABloom/ABloom.xcodeproj/project.pbxproj
@@ -7,6 +7,34 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3DB6A5722AE0BD7600C1369F /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3DB6A5712AE0BD7600C1369F /* GoogleService-Info.plist */; };
+		3DB6A5752AE0BDF800C1369F /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5742AE0BDF800C1369F /* FirebaseAnalytics */; };
+		3DB6A5772AE0BDF800C1369F /* FirebaseAnalyticsOnDeviceConversion in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5762AE0BDF800C1369F /* FirebaseAnalyticsOnDeviceConversion */; };
+		3DB6A5792AE0BDF800C1369F /* FirebaseAnalyticsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5782AE0BDF800C1369F /* FirebaseAnalyticsSwift */; };
+		3DB6A57B2AE0BDF800C1369F /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A57A2AE0BDF800C1369F /* FirebaseAnalyticsWithoutAdIdSupport */; };
+		3DB6A57D2AE0BDF800C1369F /* FirebaseAppCheck in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A57C2AE0BDF800C1369F /* FirebaseAppCheck */; };
+		3DB6A57F2AE0BDF800C1369F /* FirebaseAppDistribution-Beta in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A57E2AE0BDF800C1369F /* FirebaseAppDistribution-Beta */; };
+		3DB6A5812AE0BDF800C1369F /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5802AE0BDF800C1369F /* FirebaseAuth */; };
+		3DB6A5832AE0BDF800C1369F /* FirebaseAuthCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5822AE0BDF800C1369F /* FirebaseAuthCombine-Community */; };
+		3DB6A5852AE0BDF800C1369F /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5842AE0BDF800C1369F /* FirebaseCrashlytics */; };
+		3DB6A5872AE0BDF800C1369F /* FirebaseDatabase in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5862AE0BDF800C1369F /* FirebaseDatabase */; };
+		3DB6A5892AE0BDF800C1369F /* FirebaseDatabaseSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5882AE0BDF800C1369F /* FirebaseDatabaseSwift */; };
+		3DB6A58B2AE0BDF800C1369F /* FirebaseDynamicLinks in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A58A2AE0BDF800C1369F /* FirebaseDynamicLinks */; };
+		3DB6A58D2AE0BDF800C1369F /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A58C2AE0BDF800C1369F /* FirebaseFirestore */; };
+		3DB6A58F2AE0BDF800C1369F /* FirebaseFirestoreCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A58E2AE0BDF800C1369F /* FirebaseFirestoreCombine-Community */; };
+		3DB6A5912AE0BDF800C1369F /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5902AE0BDF800C1369F /* FirebaseFirestoreSwift */; };
+		3DB6A5932AE0BDF800C1369F /* FirebaseFunctions in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5922AE0BDF800C1369F /* FirebaseFunctions */; };
+		3DB6A5952AE0BDF800C1369F /* FirebaseFunctionsCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5942AE0BDF800C1369F /* FirebaseFunctionsCombine-Community */; };
+		3DB6A5972AE0BDF800C1369F /* FirebaseInAppMessaging-Beta in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5962AE0BDF800C1369F /* FirebaseInAppMessaging-Beta */; };
+		3DB6A5992AE0BDF800C1369F /* FirebaseInAppMessagingSwift-Beta in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5982AE0BDF800C1369F /* FirebaseInAppMessagingSwift-Beta */; };
+		3DB6A59B2AE0BDF800C1369F /* FirebaseInstallations in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A59A2AE0BDF800C1369F /* FirebaseInstallations */; };
+		3DB6A59D2AE0BDF800C1369F /* FirebaseMLModelDownloader in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A59C2AE0BDF800C1369F /* FirebaseMLModelDownloader */; };
+		3DB6A59F2AE0BDF800C1369F /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A59E2AE0BDF800C1369F /* FirebaseMessaging */; };
+		3DB6A5A12AE0BDF800C1369F /* FirebasePerformance in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5A02AE0BDF800C1369F /* FirebasePerformance */; };
+		3DB6A5A32AE0BDF800C1369F /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5A22AE0BDF800C1369F /* FirebaseRemoteConfig */; };
+		3DB6A5A52AE0BDF800C1369F /* FirebaseRemoteConfigSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5A42AE0BDF800C1369F /* FirebaseRemoteConfigSwift */; };
+		3DB6A5A72AE0BDF800C1369F /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5A62AE0BDF800C1369F /* FirebaseStorage */; };
+		3DB6A5A92AE0BDF800C1369F /* FirebaseStorageCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5A82AE0BDF800C1369F /* FirebaseStorageCombine-Community */; };
 		6053F15B2ADEB7700064A6E0 /* RegistrationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6053F15A2ADEB7700064A6E0 /* RegistrationViewModel.swift */; };
 		6053F15F2ADF6C3B0064A6E0 /* Ex+View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6053F15E2ADF6C3B0064A6E0 /* Ex+View.swift */; };
 		6053F1622ADF6CDE0064A6E0 /* InputFieldModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6053F1612ADF6CDE0064A6E0 /* InputFieldModifier.swift */; };
@@ -30,6 +58,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		3DB6A5712AE0BD7600C1369F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		6053F15A2ADEB7700064A6E0 /* RegistrationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationViewModel.swift; sourceTree = "<group>"; };
 		6053F15E2ADF6C3B0064A6E0 /* Ex+View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ex+View.swift"; sourceTree = "<group>"; };
 		6053F1612ADF6CDE0064A6E0 /* InputFieldModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputFieldModifier.swift; sourceTree = "<group>"; };
@@ -64,6 +93,33 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3DB6A5872AE0BDF800C1369F /* FirebaseDatabase in Frameworks */,
+				3DB6A5952AE0BDF800C1369F /* FirebaseFunctionsCombine-Community in Frameworks */,
+				3DB6A58D2AE0BDF800C1369F /* FirebaseFirestore in Frameworks */,
+				3DB6A5792AE0BDF800C1369F /* FirebaseAnalyticsSwift in Frameworks */,
+				3DB6A5752AE0BDF800C1369F /* FirebaseAnalytics in Frameworks */,
+				3DB6A5772AE0BDF800C1369F /* FirebaseAnalyticsOnDeviceConversion in Frameworks */,
+				3DB6A59D2AE0BDF800C1369F /* FirebaseMLModelDownloader in Frameworks */,
+				3DB6A5912AE0BDF800C1369F /* FirebaseFirestoreSwift in Frameworks */,
+				3DB6A57D2AE0BDF800C1369F /* FirebaseAppCheck in Frameworks */,
+				3DB6A57B2AE0BDF800C1369F /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */,
+				3DB6A5812AE0BDF800C1369F /* FirebaseAuth in Frameworks */,
+				3DB6A5852AE0BDF800C1369F /* FirebaseCrashlytics in Frameworks */,
+				3DB6A5A52AE0BDF800C1369F /* FirebaseRemoteConfigSwift in Frameworks */,
+				3DB6A5972AE0BDF800C1369F /* FirebaseInAppMessaging-Beta in Frameworks */,
+				3DB6A5892AE0BDF800C1369F /* FirebaseDatabaseSwift in Frameworks */,
+				3DB6A5932AE0BDF800C1369F /* FirebaseFunctions in Frameworks */,
+				3DB6A5A92AE0BDF800C1369F /* FirebaseStorageCombine-Community in Frameworks */,
+				3DB6A5A32AE0BDF800C1369F /* FirebaseRemoteConfig in Frameworks */,
+				3DB6A57F2AE0BDF800C1369F /* FirebaseAppDistribution-Beta in Frameworks */,
+				3DB6A5832AE0BDF800C1369F /* FirebaseAuthCombine-Community in Frameworks */,
+				3DB6A5A12AE0BDF800C1369F /* FirebasePerformance in Frameworks */,
+				3DB6A5992AE0BDF800C1369F /* FirebaseInAppMessagingSwift-Beta in Frameworks */,
+				3DB6A5A72AE0BDF800C1369F /* FirebaseStorage in Frameworks */,
+				3DB6A58B2AE0BDF800C1369F /* FirebaseDynamicLinks in Frameworks */,
+				3DB6A58F2AE0BDF800C1369F /* FirebaseFirestoreCombine-Community in Frameworks */,
+				3DB6A59F2AE0BDF800C1369F /* FirebaseMessaging in Frameworks */,
+				3DB6A59B2AE0BDF800C1369F /* FirebaseInstallations in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -183,6 +239,7 @@
 			isa = PBXGroup;
 			children = (
 				AE8D3C5D2ADE1A22009899A7 /* Info.plist */,
+				3DB6A5712AE0BD7600C1369F /* GoogleService-Info.plist */,
 				AE8D3C522ADE19F2009899A7 /* Fonts */,
 				AE8D3C4F2ADE19B4009899A7 /* Extensions */,
 				AE2BB5F72AD66C0F0003CD85 /* Components */,
@@ -249,6 +306,33 @@
 			);
 			name = ABloom;
 			packageProductDependencies = (
+				3DB6A5742AE0BDF800C1369F /* FirebaseAnalytics */,
+				3DB6A5762AE0BDF800C1369F /* FirebaseAnalyticsOnDeviceConversion */,
+				3DB6A5782AE0BDF800C1369F /* FirebaseAnalyticsSwift */,
+				3DB6A57A2AE0BDF800C1369F /* FirebaseAnalyticsWithoutAdIdSupport */,
+				3DB6A57C2AE0BDF800C1369F /* FirebaseAppCheck */,
+				3DB6A57E2AE0BDF800C1369F /* FirebaseAppDistribution-Beta */,
+				3DB6A5802AE0BDF800C1369F /* FirebaseAuth */,
+				3DB6A5822AE0BDF800C1369F /* FirebaseAuthCombine-Community */,
+				3DB6A5842AE0BDF800C1369F /* FirebaseCrashlytics */,
+				3DB6A5862AE0BDF800C1369F /* FirebaseDatabase */,
+				3DB6A5882AE0BDF800C1369F /* FirebaseDatabaseSwift */,
+				3DB6A58A2AE0BDF800C1369F /* FirebaseDynamicLinks */,
+				3DB6A58C2AE0BDF800C1369F /* FirebaseFirestore */,
+				3DB6A58E2AE0BDF800C1369F /* FirebaseFirestoreCombine-Community */,
+				3DB6A5902AE0BDF800C1369F /* FirebaseFirestoreSwift */,
+				3DB6A5922AE0BDF800C1369F /* FirebaseFunctions */,
+				3DB6A5942AE0BDF800C1369F /* FirebaseFunctionsCombine-Community */,
+				3DB6A5962AE0BDF800C1369F /* FirebaseInAppMessaging-Beta */,
+				3DB6A5982AE0BDF800C1369F /* FirebaseInAppMessagingSwift-Beta */,
+				3DB6A59A2AE0BDF800C1369F /* FirebaseInstallations */,
+				3DB6A59C2AE0BDF800C1369F /* FirebaseMLModelDownloader */,
+				3DB6A59E2AE0BDF800C1369F /* FirebaseMessaging */,
+				3DB6A5A02AE0BDF800C1369F /* FirebasePerformance */,
+				3DB6A5A22AE0BDF800C1369F /* FirebaseRemoteConfig */,
+				3DB6A5A42AE0BDF800C1369F /* FirebaseRemoteConfigSwift */,
+				3DB6A5A62AE0BDF800C1369F /* FirebaseStorage */,
+				3DB6A5A82AE0BDF800C1369F /* FirebaseStorageCombine-Community */,
 			);
 			productName = ABloom;
 			productReference = AE7EE4DD2AD6409000E0A573 /* ABloom.app */;
@@ -279,6 +363,7 @@
 			);
 			mainGroup = AE7EE4D42AD6409000E0A573;
 			packageReferences = (
+				3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			productRefGroup = AE7EE4DE2AD6409000E0A573 /* Products */;
 			projectDirPath = "";
@@ -296,6 +381,7 @@
 			files = (
 				AE8D3C5A2ADE1A08009899A7 /* SpoqaHanSansNeo-Thin.ttf in Resources */,
 				AE8D3C582ADE1A08009899A7 /* SpoqaHanSansNeo-Bold.ttf in Resources */,
+				3DB6A5722AE0BD7600C1369F /* GoogleService-Info.plist in Resources */,
 				AE8D3C5B2ADE1A08009899A7 /* SpoqaHanSansNeo-Light.ttf in Resources */,
 				AE2BB5F42AD650680003CD85 /* .swiftlint.yml in Resources */,
 				AE7EE4E82AD6409100E0A573 /* Preview Assets.xcassets in Resources */,
@@ -479,7 +565,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"ABloom/Preview Content\"";
-				DEVELOPMENT_TEAM = SL6KBD5WZW;
+				DEVELOPMENT_TEAM = G7X65ZSJ3J;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -510,7 +596,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"ABloom/Preview Content\"";
-				DEVELOPMENT_TEAM = SL6KBD5WZW;
+				DEVELOPMENT_TEAM = G7X65ZSJ3J;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -555,6 +641,155 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 10.16.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		3DB6A5742AE0BDF800C1369F /* FirebaseAnalytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalytics;
+		};
+		3DB6A5762AE0BDF800C1369F /* FirebaseAnalyticsOnDeviceConversion */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalyticsOnDeviceConversion;
+		};
+		3DB6A5782AE0BDF800C1369F /* FirebaseAnalyticsSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalyticsSwift;
+		};
+		3DB6A57A2AE0BDF800C1369F /* FirebaseAnalyticsWithoutAdIdSupport */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalyticsWithoutAdIdSupport;
+		};
+		3DB6A57C2AE0BDF800C1369F /* FirebaseAppCheck */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAppCheck;
+		};
+		3DB6A57E2AE0BDF800C1369F /* FirebaseAppDistribution-Beta */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = "FirebaseAppDistribution-Beta";
+		};
+		3DB6A5802AE0BDF800C1369F /* FirebaseAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAuth;
+		};
+		3DB6A5822AE0BDF800C1369F /* FirebaseAuthCombine-Community */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = "FirebaseAuthCombine-Community";
+		};
+		3DB6A5842AE0BDF800C1369F /* FirebaseCrashlytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseCrashlytics;
+		};
+		3DB6A5862AE0BDF800C1369F /* FirebaseDatabase */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseDatabase;
+		};
+		3DB6A5882AE0BDF800C1369F /* FirebaseDatabaseSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseDatabaseSwift;
+		};
+		3DB6A58A2AE0BDF800C1369F /* FirebaseDynamicLinks */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseDynamicLinks;
+		};
+		3DB6A58C2AE0BDF800C1369F /* FirebaseFirestore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseFirestore;
+		};
+		3DB6A58E2AE0BDF800C1369F /* FirebaseFirestoreCombine-Community */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = "FirebaseFirestoreCombine-Community";
+		};
+		3DB6A5902AE0BDF800C1369F /* FirebaseFirestoreSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseFirestoreSwift;
+		};
+		3DB6A5922AE0BDF800C1369F /* FirebaseFunctions */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseFunctions;
+		};
+		3DB6A5942AE0BDF800C1369F /* FirebaseFunctionsCombine-Community */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = "FirebaseFunctionsCombine-Community";
+		};
+		3DB6A5962AE0BDF800C1369F /* FirebaseInAppMessaging-Beta */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = "FirebaseInAppMessaging-Beta";
+		};
+		3DB6A5982AE0BDF800C1369F /* FirebaseInAppMessagingSwift-Beta */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = "FirebaseInAppMessagingSwift-Beta";
+		};
+		3DB6A59A2AE0BDF800C1369F /* FirebaseInstallations */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseInstallations;
+		};
+		3DB6A59C2AE0BDF800C1369F /* FirebaseMLModelDownloader */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseMLModelDownloader;
+		};
+		3DB6A59E2AE0BDF800C1369F /* FirebaseMessaging */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseMessaging;
+		};
+		3DB6A5A02AE0BDF800C1369F /* FirebasePerformance */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebasePerformance;
+		};
+		3DB6A5A22AE0BDF800C1369F /* FirebaseRemoteConfig */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseRemoteConfig;
+		};
+		3DB6A5A42AE0BDF800C1369F /* FirebaseRemoteConfigSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseRemoteConfigSwift;
+		};
+		3DB6A5A62AE0BDF800C1369F /* FirebaseStorage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseStorage;
+		};
+		3DB6A5A82AE0BDF800C1369F /* FirebaseStorageCombine-Community */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3DB6A5732AE0BDF800C1369F /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = "FirebaseStorageCombine-Community";
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = AE7EE4D52AD6409000E0A573 /* Project object */;
 }

--- a/ABloom/ABloom.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ABloom/ABloom.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,113 @@
+{
+  "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "bfc0b6f81adc06ce5121eb23f628473638d67c5c",
+        "version" : "1.2022062300.0"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk",
+      "state" : {
+        "revision" : "837d4af6ead57cec1fc38007892500d3139c7556",
+        "version" : "10.16.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "56f681586ff006a7982b53dc94082eea31971acf",
+        "version" : "10.16.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "aae45a320fd0d11811820335b1eabc8753902a40",
+        "version" : "9.2.5"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "c38ce365d77b04a9a300c31061c5227589e5597b",
+        "version" : "7.11.5"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "a673bc2937fbe886dd1f99c401b01b6d977a9c98",
+        "version" : "1.49.1"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "d415594121c9e8a4f9d79cecee0965cf35e74dbd",
+        "version" : "3.1.1"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
+        "version" : "100.0.0"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "0706abcc6b0bd9cedfbb015ba840e4a780b5159b",
+        "version" : "1.22.2"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "819d0a2173aff699fb8c364b6fb906f7cdb1a692",
+        "version" : "2.30909.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "e70e889c0196c76d22759eb50d6a0270ca9f1d9e",
+        "version" : "2.3.1"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "3c54ab05249f59f2c6641dd2920b8358ea9ed127",
+        "version" : "1.24.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/ABloom/ABloom/ABloom.entitlements
+++ b/ABloom/ABloom/ABloom.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/ABloom/ABloom/ABloomApp.swift
+++ b/ABloom/ABloom/ABloomApp.swift
@@ -5,9 +5,15 @@
 //  Created by yun on 10/11/23.
 //
 import SwiftUI
+import FirebaseCore
 
 @main
 struct ABloomApp: App {
+  
+  init() {
+    FirebaseApp.configure()
+    print("Firebase configured!")
+  }
   
   var body: some Scene {
     WindowGroup {

--- a/ABloom/ABloom/ABloomApp.swift
+++ b/ABloom/ABloom/ABloomApp.swift
@@ -17,7 +17,8 @@ struct ABloomApp: App {
   
   var body: some Scene {
     WindowGroup {
-      TabBarView()
+//      TabBarView()
+      LoginView()
     }
   }
 }

--- a/ABloom/ABloom/Firebase/Authentication/SignInAppleHelper.swift
+++ b/ABloom/ABloom/Firebase/Authentication/SignInAppleHelper.swift
@@ -1,0 +1,158 @@
+//
+//  SignInAppleHelper.swift
+//  ABloom
+//
+//  Created by 정승균 on 10/19/23.
+//
+
+import Foundation
+
+import SwiftUI
+import AuthenticationServices
+import CryptoKit
+
+/// 애플 로그인 성공시 리턴 받을 데이터입니다.
+struct SignInWithAppleResult {
+  let token: String
+  let nonce: String
+  let fullName: PersonNameComponents?
+}
+
+@MainActor
+final class SignInAppleHelper: NSObject {
+  
+  private var currentNonce: String?
+  private var completionHandler: ((Result<SignInWithAppleResult, Error>) -> Void)? = nil
+  
+  /// 애플 로그인을 제어합니다.
+  func startSignInWithAppleFlow() async throws -> SignInWithAppleResult {
+    try await withCheckedThrowingContinuation { continuation in
+      self.startSignInWithAppleFlow { result in
+        switch result {
+        case .success(let signInAppleResult):
+          continuation.resume(returning: signInAppleResult)
+          return
+        case .failure(let error):
+          continuation.resume(throwing: error)
+          return
+        }
+      }
+    }
+  }
+  
+  /// 애플 로그인 시 필요한 기본 플로우입니다.
+  private func startSignInWithAppleFlow(completion: @escaping (Result<SignInWithAppleResult, Error>) -> Void) {
+    guard let topVC = topViewController() else {
+      completion(.failure(URLError(.badURL)))
+      return
+    }
+    let nonce = randomNonceString()
+    currentNonce = nonce
+    
+    completionHandler = completion
+    
+    let appleIDProvider = ASAuthorizationAppleIDProvider()
+    let request = appleIDProvider.createRequest()
+    request.requestedScopes = [.fullName] // 애플 로그인을 통해 제공 받을 부분은 이름입니다.
+    request.nonce = sha256(nonce)
+    
+    let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+    authorizationController.delegate = self
+    authorizationController.presentationContextProvider = topVC
+    authorizationController.performRequests()
+  }
+  
+  /// 랜덤 난수 생성기 -> 로그인 요청시 토큰이 명시적으로 부여되었는지 확인, 재전송 공격 방지
+  private func randomNonceString(length: Int = 32) -> String {
+    precondition(length > 0)
+    var randomBytes = [UInt8](repeating: 0, count: length)
+    let errorCode = SecRandomCopyBytes(kSecRandomDefault, randomBytes.count, &randomBytes)
+    if errorCode != errSecSuccess {
+      fatalError(
+        "Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)"
+      )
+    }
+    
+    let charset: [Character] =
+    Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+    
+    let nonce = randomBytes.map { byte in
+      // Pick a random character from the set, wrapping around if needed.
+      charset[Int(byte) % charset.count]
+    }
+    
+    return String(nonce)
+  }
+  
+  /// sha256으로 해싱하기 위한 메서드입니다.
+  @available(iOS 13, *)
+  private func sha256(_ input: String) -> String {
+    let inputData = Data(input.utf8)
+    let hashedData = SHA256.hash(data: inputData)
+    let hashString = hashedData.compactMap {
+      String(format: "%02x", $0)
+    }.joined()
+    
+    return hashString
+  }
+}
+
+extension SignInAppleHelper: ASAuthorizationControllerDelegate {
+  /// 인증 성공 시 실행되는 메서드입니다.
+  func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+    
+    guard
+      let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential,
+      let nonce = currentNonce,
+      let appleIDToken = appleIDCredential.identityToken,
+      let idTokenString = String(data: appleIDToken, encoding: .utf8) else {
+      completionHandler?(.failure(URLError(.badServerResponse)))
+      return
+    }
+    
+    let tokens = SignInWithAppleResult(token: idTokenString, nonce: nonce, fullName: appleIDCredential.fullName)
+    
+    completionHandler?(.success(tokens))
+  }
+  
+  /// 인증 에러시 에러를 제어하는 메서드입니다.
+  func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+    // Handle error.
+    print("Sign in with Apple errored: \(error)")
+    completionHandler?(.failure(URLError(.cannotFindHost)))
+  }
+  
+}
+
+extension UIViewController: ASAuthorizationControllerPresentationContextProviding {
+  public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+    return self.view.window!
+  }
+}
+
+extension SignInAppleHelper {
+  
+  /// 최상단 뷰 컨트롤러에 애플 로그인 뷰를 보여줄 수 있도록 최상단 뷰 컨트롤러를 찾는 메서드입니다.
+  /// SwiftUI는 ViewController를 제공하지 않기 때문에, 임의의 함수를 구현하여 사용합니다.
+  /// 다른 로그인 구현시 필요하다면 외부 함수 & 클래스로 빠져야하는 부분입니다.
+  func topViewController(controller: UIViewController? = nil) -> UIViewController? {
+    
+    let controller = controller ?? UIApplication.shared.keyWindow?.rootViewController
+    
+    if let navigationController = controller as? UINavigationController {
+      return topViewController(controller: navigationController.visibleViewController)
+    }
+    
+    if let tabController = controller as? UITabBarController {
+      if let selected = tabController.selectedViewController {
+        return topViewController(controller: selected)
+      }
+    }
+    
+    if let presented = controller?.presentedViewController {
+      return topViewController(controller: presented)
+    }
+    
+    return controller
+  }
+}

--- a/ABloom/ABloom/GoogleService-Info.plist
+++ b/ABloom/ABloom/GoogleService-Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>AIzaSyAl9VtUSQNAwLw-sKcUGe-JRKQKrghnI5I</string>
+	<key>GCM_SENDER_ID</key>
+	<string>1084458003329</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>com.abloom.ABloom</string>
+	<key>PROJECT_ID</key>
+	<string>mery-e2cff</string>
+	<key>STORAGE_BUCKET</key>
+	<string>mery-e2cff.appspot.com</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:1084458003329:ios:74b1934ddb9b522df25680</string>
+</dict>
+</plist>

--- a/ABloom/ABloom/Login/LoginView.swift
+++ b/ABloom/ABloom/Login/LoginView.swift
@@ -1,0 +1,30 @@
+//
+//  LoginView.swift
+//  ABloom
+//
+//  Created by 정승균 on 10/19/23.
+//
+
+import SwiftUI
+
+struct LoginView: View {
+  var body: some View {
+    VStack {
+      Spacer()
+      
+      Button {
+        
+      } label: {
+        SignInWithAppleButtonViewRepresentable(type: .continue, style: .black)
+          .allowsHitTesting(false)
+      }
+      .frame(height: 56)
+      .padding(.horizontal, 20)
+      .padding(.bottom, 60)
+    }
+  }
+}
+
+#Preview {
+  LoginView()
+}

--- a/ABloom/ABloom/Login/LoginView.swift
+++ b/ABloom/ABloom/Login/LoginView.swift
@@ -8,12 +8,23 @@
 import SwiftUI
 
 struct LoginView: View {
+  @StateObject var loginVM = LoginViewModel()
+  
   var body: some View {
     VStack {
       Spacer()
       
+      if let user = loginVM.user {
+          Text("User Id \(user.uid)")
+        if let name = user.name {
+          Text("User Name \(name)")
+        }
+      }
+      
       Button {
-        
+        Task {
+          try await loginVM.signInApple()
+        }
       } label: {
         SignInWithAppleButtonViewRepresentable(type: .continue, style: .black)
           .allowsHitTesting(false)

--- a/ABloom/ABloom/Login/LoginViewModel.swift
+++ b/ABloom/ABloom/Login/LoginViewModel.swift
@@ -1,0 +1,54 @@
+//
+//  LoginViewModel.swift
+//  ABloom
+//
+//  Created by 정승균 on 10/19/23.
+//
+
+import Foundation
+import FirebaseAuth
+
+/// Firebase에 저장된 정보를 쉽게 가져올 수 있도록 생성한 구조체입니다.
+struct AuthDataResultModel {
+  let uid: String
+  let name: String?
+  
+  init(user: User) {
+    self.uid = user.uid
+    self.name = user.displayName
+  }
+}
+
+@MainActor
+final class LoginViewModel: ObservableObject {
+  @Published var user: AuthDataResultModel? = nil
+  
+  /// Apple ID로 로그인합니다.
+  func signInApple() async throws {
+    let helper = SignInAppleHelper()
+    let tokens = try await helper.startSignInWithAppleFlow()
+    let authDataResult = try await signInWithApple(tokens: tokens)
+    self.user = authDataResult
+    //  let user = DBUser(auth: authDataResult)
+    //  try UserManager.shared.createNewUser(user: user)
+  }
+  
+  /// Apple Login Flow를 통해 저장된 토큰 값을 이용해 Credential을 제공받고, 사용자 정보 모델을 리턴합니다.
+  ///
+  /// - Parameters:
+  ///   - tokens: 애플 로그인을 통해 얻은 모델을 전달합니다.
+  ///
+  /// - Returns:
+  ///   - AuthDataResultModel: 유저의 정보를 리턴합니다.
+  @discardableResult
+  private func signInWithApple(tokens: SignInWithAppleResult) async throws -> AuthDataResultModel {
+    let credential = OAuthProvider.appleCredential(withIDToken: tokens.token,
+                                                   rawNonce: tokens.nonce,
+                                                   fullName: tokens.fullName)
+    
+    let authDataResult = try await Auth.auth().signIn(with: credential)
+    
+    return AuthDataResultModel(user: authDataResult.user)
+  }
+}
+

--- a/ABloom/ABloom/Login/SubViews/AppleLoginButtonViewRepresentable.swift
+++ b/ABloom/ABloom/Login/SubViews/AppleLoginButtonViewRepresentable.swift
@@ -8,6 +8,17 @@
 import SwiftUI
 import AuthenticationServices
 
+/// 애플에 내장된 로그인 버튼을 구현할 수 있는 UIViewRepresentable입니다.
+///
+/// - Parameters:
+///     - type: 버튼의 안내 메세지를 설정합니다.
+///     - style: 버튼의 스타일을 설정합니다.
+/// - Returns: Apple 로그인 버튼을 표시합니다.
+///
+/// ```swift
+/// // 버튼 생성 예시
+/// SignInWithAppleButtonViewRepresentable(type: .continue, style: .black)
+/// ```
 struct SignInWithAppleButtonViewRepresentable: UIViewRepresentable {
   
   let type: ASAuthorizationAppleIDButton.ButtonType

--- a/ABloom/ABloom/Login/SubViews/AppleLoginButtonViewRepresentable.swift
+++ b/ABloom/ABloom/Login/SubViews/AppleLoginButtonViewRepresentable.swift
@@ -1,0 +1,24 @@
+//
+//  AppleLoginButtonViewRepresentable.swift
+//  ABloom
+//
+//  Created by 정승균 on 10/19/23.
+//
+
+import SwiftUI
+import AuthenticationServices
+
+struct SignInWithAppleButtonViewRepresentable: UIViewRepresentable {
+  
+  let type: ASAuthorizationAppleIDButton.ButtonType
+  let style: ASAuthorizationAppleIDButton.Style
+  
+  func makeUIView(context: Context) -> ASAuthorizationAppleIDButton {
+    return ASAuthorizationAppleIDButton(type: type, style: style)
+  }
+  
+  func updateUIView(_ uiView: UIViewType, context: Context) {
+    
+  }
+  
+}


### PR DESCRIPTION
#### Related #12 

### ✏️ 개요
애플 로그인을 구현하였습니다.

### 💻 작업 사항
- 애플리케이션에서 애플 로그인을 할 수 있도록 구현하였습니다.
- Firebase의 Authentication을 통해 인증하는 기능을 구현하였습니다.
- 애플 로그인 버튼을 SwiftUI에서 사용하기 쉽도록 UIViewRepresentable을 구현하였습니다.

### 📄 리뷰 노트
- Apple 로그인만 집중적으로 구현하다보니, 클래스 내부에 함수의 무게가 조금 무거운 경향이 있습니다.
- 로그인 기능만 구현이 되어있어, 추후 로그아웃 기능또한 구현할 필요가 있습니다.
- 내용은 Firebase의 기본 가이드라인을 기반으로 하여, 메서드들의 주석만 참고하시면 됩니다.

### 📱결과 화면(optional)

|로그인뷰|애플 로그인 뷰|
|------|---|
|![image](https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/77708819/6e9bb2a7-a1d4-4352-8fb5-121704627fc2)|![image](https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/77708819/7602ff4a-fe4e-4b4f-a0b4-917c6795866a)|

|비밀번호 입력|로그인 성공 시 데이터 출력|
|------|---|
|![image](https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/77708819/453fb769-3191-44c6-981c-c86f97ed317b)|![image](https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/77708819/0b8bbc1a-de4c-4bcd-84cf-d5b23300a495)|


