### PR TITLE
[Design/#22] 유저 정보 입력 화면 디자인 적용

### DIFF
--- a/ABloom/ABloom/Components/InputFieldModifier.swift
+++ b/ABloom/ABloom/Components/InputFieldModifier.swift
@@ -16,21 +16,23 @@ struct StrokeInputFieldStyle: ViewModifier {
     ZStack(alignment: alignment) {
       RoundedRectangle(cornerRadius: cornerRadius)
         .stroke(
-          isValueValid ? .red : .pink,
-          lineWidth: isValueValid ? 2.5 : 1.0
+          isValueValid ? .pink500 : .biPink,
+          lineWidth: isValueValid ? 1.5 : 1.0
         )
+        .frame(height: 50)
+        .background(.white)
+        .cornerRadius(cornerRadius)
         
       content
-        .foregroundStyle(isValueValid ? .black : .gray)
+        .foregroundStyle(isValueValid ? .stone900 : .stone400)
         .padding(
           EdgeInsets(
             top: 0,
-            leading: alignment == .leading ? 16 : 0,
+            leading: 16,
             bottom: 0,
-            trailing: alignment == .trailing ? 16 : 0)
+            trailing: 16)
         )
     }
-    .frame(height: 50)
-    .background(.white)
+    .tint(.pink500)
   }
 }

--- a/ABloom/ABloom/Components/InputFieldModifier.swift
+++ b/ABloom/ABloom/Components/InputFieldModifier.swift
@@ -25,13 +25,7 @@ struct StrokeInputFieldStyle: ViewModifier {
         
       content
         .foregroundStyle(isValueValid ? .stone900 : .stone400)
-        .padding(
-          EdgeInsets(
-            top: 0,
-            leading: 16,
-            bottom: 0,
-            trailing: 16)
-        )
+        .padding(.horizontal, 16)
     }
     .tint(.pink500)
   }

--- a/ABloom/ABloom/Presentation/Registration/View/RegistrationView.swift
+++ b/ABloom/ABloom/Presentation/Registration/View/RegistrationView.swift
@@ -11,19 +11,84 @@ struct RegistrationView: View {
   @StateObject var registerVM = RegistrationViewModel()
   
   var body: some View {
+    VStack(alignment: .leading, spacing: 30) {
+      
+      Spacer().frame(height: 98)
+      
+      nameInputField
+      
+      typeInputField
+      
+      marriageDateInputField
+      
+      Spacer()
+      
+      NavigationLink {
+        // ConnectView()
+      } label: {
+        if registerVM.isNextButtonEnabled {
+          PinkSingleBtn(text: "다음")
+            .frame(maxWidth: .infinity)
+        } else {
+          StoneSingleBtn(text: "다음")
+            .frame(maxWidth: .infinity)
+        }
+      }
+      .disabled(!registerVM.isNextButtonEnabled)
+      
+      Spacer().frame(height: 60)
+    }
+    .padding(.horizontal, 20)
+    .background(backgroundDefault())
+    .ignoresSafeArea()
+    .navigationTitle("가입하기")
+    .navigationBarTitleDisplayMode(.inline)
+    .sheet(isPresented: $registerVM.isShowingDatePicker) {
+      DatePicker("", selection: $registerVM.weddingDate, displayedComponents: .date)
+        .datePickerStyle(.graphical)
+        .frame(width: 320)
+        .labelsHidden()
+        .presentationDetents([.medium])
+      Button {
+        registerVM.isDatePickerTapped = true
+        registerVM.isShowingDatePicker = false
+      } label: {
+        Text("완료")
+      }
+    }
+    .tint(.pink500)
+  }
+}
+
+extension RegistrationView {
+  private var nameInputField: some View {
     VStack(alignment: .leading, spacing: 6) {
-      
       Text("이름")
-      TextField("홍길동", text: $registerVM.userName)
-        .strokeInputFieldStyle(isValueValid: registerVM.isUserNameValid, alignment: .leading)
-      
+        .fontWithTracking(fontStyle: .subHeadlineR)
+      ZStack(alignment: .leading) {
+        if !registerVM.isUserNameValid {
+          Text("홍길동")
+        }
+        TextField("", text: $registerVM.userName)
+          .foregroundStyle(.stone900)
+      }
+      .strokeInputFieldStyle(isValueValid: registerVM.isUserNameValid, alignment: .leading)
+      .font(.calloutR).tracking(-0.4)
+    }
+  }
+  
+  private var typeInputField: some View {
+    VStack(alignment: .leading, spacing: 6) {
       Text("가입유형")
+        .fontWithTracking(fontStyle: .subHeadlineR)
+      
       HStack(spacing: 18) {
         ForEach(UserType.allCases, id: \.self) { user in
           Button {
             registerVM.userType = user
           } label: {
             Text("\(user.rawValue)")
+              .fontWithTracking(fontStyle: .calloutR, value: -0.4)
               .multilineTextAlignment(.center)
               .strokeInputFieldStyle(
                 isValueValid: registerVM.isUserTypeValid(type: user),
@@ -32,42 +97,26 @@ struct RegistrationView: View {
           }
         }
       }
-      
+    }
+  }
+  
+  private var marriageDateInputField: some View {
+    VStack(alignment: .leading, spacing: 6) {
       Text("결혼 예정일")
+        .fontWithTracking(fontStyle: .subHeadlineR)
+      
       Text("\(registerVM.formattedWeddingDate)")
+        .fontWithTracking(fontStyle: .calloutR, value: -0.4)
         .strokeInputFieldStyle(isValueValid: registerVM.isWeddingDateValid, alignment: .leading)
         .onTapGesture {
-          registerVM.isDatePickerTapped = true
           registerVM.isShowingDatePicker = true
         }
-      
-      Button {
-        print("Complete")
-      } label: {
-        Text("다음")
-          .foregroundStyle(.white)
-          .frame(width: 200, height: 40)
-          .background(registerVM.isNextButtonEnabled ? Color.blue : Color.gray)
-      }
-      .disabled(!registerVM.isNextButtonEnabled)
-    }
-    .padding(.all, 20)
-    .ignoresSafeArea()
-    .sheet(isPresented: $registerVM.isShowingDatePicker) {
-      DatePicker("", selection: $registerVM.weddingDate, displayedComponents: .date)
-        .datePickerStyle(.graphical)
-        .frame(width: 320)
-        .labelsHidden()
-      
-      Button {
-        registerVM.isShowingDatePicker = false
-      } label: {
-        Text("완료")
-      }
     }
   }
 }
 
 #Preview {
-  RegistrationView()
+  NavigationStack {
+    RegistrationView()
+  }
 }

--- a/ABloom/ABloom/Presentation/Registration/View/RegistrationView.swift
+++ b/ABloom/ABloom/Presentation/Registration/View/RegistrationView.swift
@@ -12,7 +12,6 @@ struct RegistrationView: View {
   
   var body: some View {
     VStack(alignment: .leading, spacing: 30) {
-      
       Spacer().frame(height: 98)
       
       nameInputField
@@ -23,40 +22,16 @@ struct RegistrationView: View {
       
       Spacer()
       
-      NavigationLink {
-        // ConnectView()
-      } label: {
-        if registerVM.isNextButtonEnabled {
-          PinkSingleBtn(text: "다음")
-            .frame(maxWidth: .infinity)
-        } else {
-          StoneSingleBtn(text: "다음")
-            .frame(maxWidth: .infinity)
-        }
-      }
-      .disabled(!registerVM.isNextButtonEnabled)
+      nextButton
       
       Spacer().frame(height: 60)
     }
     .padding(.horizontal, 20)
     .background(backgroundDefault())
+    .tint(.pink500)
     .ignoresSafeArea()
     .navigationTitle("가입하기")
     .navigationBarTitleDisplayMode(.inline)
-    .sheet(isPresented: $registerVM.isShowingDatePicker) {
-      DatePicker("", selection: $registerVM.weddingDate, displayedComponents: .date)
-        .datePickerStyle(.graphical)
-        .frame(width: 320)
-        .labelsHidden()
-        .presentationDetents([.medium])
-      Button {
-        registerVM.isDatePickerTapped = true
-        registerVM.isShowingDatePicker = false
-      } label: {
-        Text("완료")
-      }
-    }
-    .tint(.pink500)
   }
 }
 
@@ -65,6 +40,7 @@ extension RegistrationView {
     VStack(alignment: .leading, spacing: 6) {
       Text("이름")
         .fontWithTracking(fontStyle: .subHeadlineR)
+      
       ZStack(alignment: .leading) {
         if !registerVM.isUserNameValid {
           Text("홍길동")
@@ -112,6 +88,35 @@ extension RegistrationView {
           registerVM.isShowingDatePicker = true
         }
     }
+    
+    .sheet(isPresented: $registerVM.isShowingDatePicker) {
+      DatePicker("", selection: $registerVM.weddingDate, displayedComponents: .date)
+        .datePickerStyle(.graphical)
+        .frame(width: 320)
+        .labelsHidden()
+        .presentationDetents([.medium])
+      Button {
+        registerVM.isDatePickerTapped = true
+        registerVM.isShowingDatePicker = false
+      } label: {
+        Text("완료")
+      }
+    }
+  }
+  
+  private var nextButton: some View {
+    Button {
+      // ConnectView()
+    } label: {
+      if registerVM.isNextButtonEnabled {
+        PinkSingleBtn(text: "다음")
+          .frame(maxWidth: .infinity)
+      } else {
+        StoneSingleBtn(text: "다음")
+          .frame(maxWidth: .infinity)
+      }
+    }
+    .disabled(!registerVM.isNextButtonEnabled)
   }
 }
 

--- a/ABloom/ABloom/Presentation/Registration/ViewModel/RegistrationViewModel.swift
+++ b/ABloom/ABloom/Presentation/Registration/ViewModel/RegistrationViewModel.swift
@@ -54,17 +54,12 @@ class RegistrationViewModel: ObservableObject {
     isFieldValid(.radio, value: type.rawValue, selectedType: userType)
   }
   
-  private func isFieldValid(_ type: InputField, value: String?, selectedType: UserType? = nil) -> Bool {
+  private func isFieldValid(_ type: InputField, value: String, selectedType: UserType? = nil) -> Bool {
     switch type {
     case .datePicker:
       return isDatePickerTapped
     case .text:
-      if let text = value {
-        return !text.isEmpty
-      }
-      else {
-        return false
-      }
+      return !value.isEmpty
     case .radio:
       return selectedType != nil && selectedType?.rawValue == value
     }


### PR DESCRIPTION
#### relate #22 

### ✏️ 개요
유저 정보 입력화면에 디자인을 적용합니다.

### 💻 작업 사항
- [x] 유저 정보 입력뷰에 tint값 적용
- [x] InputFieldModifier 디자인 적용
- [x] 유저정보 입력 화면 디자인 적용

### 📄 리뷰 노트
참고할 부분은 코멘트로 남겨두겠습니다! 

### 📱결과 화면(optional)
<img src = "https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/100195563/a3546c48-ec08-47f3-8073-cbc481aa8eb4" width = "300">
<img src = "https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/100195563/d41b9bbc-d64a-4123-a37d-edbda096fabb" width = "300">

### 📚 ETC(optional)
네비게이션으로 연결해두지 않아서 title이 뜨지 않습니다 !
title이 커스텀폰트여서 추후에 다른 뷰와 같이 작업할 듯 합니다 !

