### PR TITLE
[Feat/#46] 로그인뷰 레이아웃 적용

### DIFF
--- a/ABloom/ABloom/Presentation/BoundaryViews/Login/LoginView.swift
+++ b/ABloom/ABloom/Presentation/BoundaryViews/Login/LoginView.swift
@@ -12,33 +12,152 @@ struct LoginView: View {
   @Binding var showLoginView: Bool
   
   var body: some View {
-    VStack {
+    VStack(spacing: 12) {
+      Spacer().frame(maxHeight: 90)
+      
+      titleArea
+      
+      Spacer().frame(maxHeight: 30)
+
+      chatBubbleArea
+      
       Spacer()
       
-      Button {
-        Task {
-          try await loginVM.signInApple()
-        }
-      } label: {
-        SignInWithAppleButtonViewRepresentable(type: .continue, style: .black)
-          .allowsHitTesting(false)
-      }
-      .frame(height: 56)
-      .padding(.horizontal, 20)
-      .padding(.bottom, 60)
+      buttonArea
+      
+      bottomArea
     }
+    .padding(.horizontal, 20)
+    .background(
+      backgroundDefault()
+    )
+    
+    /// Login Task
     .task {
       try? loginVM.loadCurrentUser()
     }
     .navigationDestination(isPresented: $loginVM.isSignInSuccess) {
       RegistrationView(showLoginView: $showLoginView)
     }
-    .background(backgroundDefault())
   }
 }
 
 #Preview {
   NavigationStack {
     LoginView(showLoginView: .constant(true))
+  }
+}
+
+extension LoginView {
+  private var titleArea: some View {
+    HStack {
+      VStack(alignment: .leading, spacing: 11) {
+        Text("예비부부가 함께 써내려가는\n둘 만의 결혼문답")
+          .fontWithTracking(.title2Bold, tracking: -0.4)
+          .foregroundStyle(.stone600)
+          .frame(minHeight: 72)
+        Text("MERY")
+          .fontWithTracking(.largeTitleBold)
+          .foregroundStyle(.stone950)
+      }
+      .multilineTextAlignment(.leading)
+      
+      Spacer()
+    }
+  }
+  
+  private var chatBubbleArea: some View {
+    VStack(spacing: 0) {
+      
+      chatBubbleBlue
+      
+      chatBubblePink
+      
+      ForEach(0..<3) { _ in
+        Circle()
+          .frame(width: 8, height: 8)
+          .foregroundStyle(.stone300)
+          .padding(.vertical, 6)
+      }
+      
+    }
+  }
+  
+  private var chatBubbleBlue: some View {
+    HStack {
+      RoundedRectangle(cornerRadius: 12)
+        .loginChatBubbleShadow()
+        .foregroundStyle(.blue100)
+        .frame(width: 260, height: 50)
+        .overlay(alignment: .leading) {
+          Text("돈관리는 어떻게 하는 게 좋을까?")
+            .foregroundStyle(.stone800)
+            .font(.custom("SpoqaHanSansNeo-Medium", size: 14))
+            .tracking(-0.4)
+            .padding(.leading, 50)
+        }
+        .offset(x: -44)
+      
+      Spacer()
+    }
+    .padding(.bottom, 22)
+  }
+  
+  private var chatBubblePink: some View {
+    HStack {
+      Spacer()
+      
+      RoundedRectangle(cornerRadius: 12)
+        .loginChatBubbleShadow()
+        .frame(width: 310, height: 74)
+        .foregroundStyle(.pink100)
+        .overlay(alignment: .leading) {
+          Text("부모님들이 건강이 안 좋아지시거나 해서\n누군가 모셔야 한다면 어떻게 할까?")
+            .foregroundStyle(.stone800)
+            .font(.custom("SpoqaHanSansNeo-Medium", size: 14))
+            .tracking(-0.4)
+            .lineSpacing(2)
+            .padding(.leading, 20)
+        }
+        .offset(x: 44)
+        .padding(.bottom, 26)
+    }
+  }
+  
+  private var buttonArea: some View {
+    Button {
+      Task {
+        try await loginVM.signInApple()
+      }
+    } label: {
+      SignInWithAppleButtonViewRepresentable(type: .continue, style: .black)
+        .allowsHitTesting(false)
+    }
+    .frame(height: 56)
+    .padding(.bottom, 10)
+  }
+  
+  private var bottomArea: some View {
+    VStack(spacing: 12) {
+      VStack(spacing: 0) {
+        Text("로그인하시면 만 14세 이상이고,")
+        Text("아래 내용에 동의하는 것으로 간주됩니다.")
+      }
+      .fontWithTracking(.footnoteR, tracking: -0.4)
+      .foregroundStyle(.stone800)
+      .multilineTextAlignment(.center)
+      
+      HStack(spacing: 24) {
+        Button(action: {}, label: {
+          Text("개인정보처리방침").underline()
+        })
+        Button(action: {}, label: {
+          Text("이용약관").underline()
+        })
+      }
+      .fontWithTracking(.caption1R, tracking: -0.4)
+      .foregroundStyle(.stone600)
+      .padding(.bottom, 36)
+    }
   }
 }

--- a/ABloom/ABloom/Resources/Extensions/Ex+Shape.swift
+++ b/ABloom/ABloom/Resources/Extensions/Ex+Shape.swift
@@ -94,4 +94,12 @@ extension Shape {
     )
     .shadow(color: Color.purple200.opacity(1), radius: 20, x: 0, y: 20)
   }
+  
+  public func loginChatBubbleShadow() -> some View {
+    self.fill(
+      .shadow(.inner(color: Color.black.opacity(0.06), radius: 5, x: 0, y: -3))
+      .shadow(.inner(color: Color.white.opacity(0.6), radius: 8, x: 3, y: 1))
+    )
+    .shadow(color: Color.black.opacity(0.08), radius: 10, x: 0, y: 7.45)
+  }
 }


### PR DESCRIPTION
#### related #46 

### ✏️ 개요
로그인뷰 레이아웃을 적용하였습니다.

### 💻 작업 사항
SE에서도 화면이 깨지지 않도록 작업하였습니다.
로그인뷰의 챗버블에 쓰이는 스타일이 스타일가이드에 있는 것이 아닌 커스텀된 스타일이어서 새로 추가해두었습니다!

### 📄 리뷰 노트
로그인뷰의 챗버블을 구현할 때 view Extension에서 구현한 cornerRadius 와 loginChatBubbleShadow를 같이 사용하면 
원래 의도와 다르게 적용되어서, 원래 사이즈보다 너비를 키우고 offset으로 이동시키는 방식으로 구현했습니다.

### 📱결과 화면(optional)
<img src = "https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/100195563/c84b8e83-778c-45f5-a607-f2379f1bb681" width = "300"> 

