### PR TITLE
[Design/59] QuestionView 디자인 수정 및 완료

### DIFF
--- a/ABloom/ABloom.xcodeproj/project.pbxproj
+++ b/ABloom/ABloom.xcodeproj/project.pbxproj
@@ -21,11 +21,11 @@
 		3D4412622AE509C600FD5A51 /* MyAccountConnectingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D4412612AE509C600FD5A51 /* MyAccountConnectingViewModel.swift */; };
 		3D4412642AE50E8E00FD5A51 /* MyAccountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D4412632AE50E8E00FD5A51 /* MyAccountViewModel.swift */; };
 		3D44126B2AE6246100FD5A51 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3D44126A2AE6246100FD5A51 /* Assets.xcassets */; };
+		3D4412782AE9F5E600FD5A51 /* ServiceWebURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D4412772AE9F5E600FD5A51 /* ServiceWebURL.swift */; };
 		3D44127A2AEAB34000FD5A51 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3D4412792AEAB34000FD5A51 /* GoogleService-Info.plist */; };
 		3D44127C2AEAC3C000FD5A51 /* ConnectedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D44127B2AEAC3C000FD5A51 /* ConnectedView.swift */; };
 		3D44127E2AEAC57500FD5A51 /* ConnectionWaypointView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D44127D2AEAC57500FD5A51 /* ConnectionWaypointView.swift */; };
 		3D4412802AEACA2A00FD5A51 /* ConnectionWaypointViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D44127F2AEACA2A00FD5A51 /* ConnectionWaypointViewModel.swift */; };
-		3D4412782AE9F5E600FD5A51 /* ServiceWebURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D4412772AE9F5E600FD5A51 /* ServiceWebURL.swift */; };
 		3DB6A5752AE0BDF800C1369F /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5742AE0BDF800C1369F /* FirebaseAnalytics */; };
 		3DB6A5772AE0BDF800C1369F /* FirebaseAnalyticsOnDeviceConversion in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5762AE0BDF800C1369F /* FirebaseAnalyticsOnDeviceConversion */; };
 		3DB6A5792AE0BDF800C1369F /* FirebaseAnalyticsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5782AE0BDF800C1369F /* FirebaseAnalyticsSwift */; };
@@ -74,7 +74,6 @@
 		AE1AEA012AE55A0C0010089F /* QuestionMainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1AEA002AE55A0C0010089F /* QuestionMainViewModel.swift */; };
 		AE2BB5F42AD650680003CD85 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = AE2BB5F32AD650680003CD85 /* .swiftlint.yml */; };
 		AE5693252AEAD982009F3400 /* AnswerWriteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE5693242AEAD982009F3400 /* AnswerWriteViewModel.swift */; };
-		AE66978E2AE8FC100004B56C /* SelectQuestionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE66978D2AE8FC100004B56C /* SelectQuestionViewModel.swift */; };
 		AE6697902AE904F80004B56C /* AnswerWriteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE66978F2AE904F80004B56C /* AnswerWriteView.swift */; };
 		AE6ACF552AE0B49E0017088C /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6ACF542AE0B49E0017088C /* Helpers.swift */; };
 		AE7EE4E12AD6409000E0A573 /* ABloomApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7EE4E02AD6409000E0A573 /* ABloomApp.swift */; };
@@ -87,11 +86,12 @@
 		AE8D3C5C2ADE1A08009899A7 /* SpoqaHanSansNeo-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AE8D3C572ADE1A08009899A7 /* SpoqaHanSansNeo-Medium.ttf */; };
 		AE8D3C612ADE3C73009899A7 /* Ex+Shape.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE8D3C602ADE3C73009899A7 /* Ex+Shape.swift */; };
 		AEAB19372ADF77210057BC43 /* Buttons.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEAB19362ADF77210057BC43 /* Buttons.swift */; };
-		AEB502622AE5F5340056E439 /* SelectQuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB502612AE5F5340056E439 /* SelectQuestionView.swift */; };
 		AEB502642AE5FA840056E439 /* CustomNavigationBarModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB502632AE5FA840056E439 /* CustomNavigationBarModifier.swift */; };
 		AEB5026B2AE64B8D0056E439 /* CategoryQuestionBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB5026A2AE64B8D0056E439 /* CategoryQuestionBox.swift */; };
 		AEC260612AEA5A8000DF7CD5 /* StaticQuestionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC260602AEA5A8000DF7CD5 /* StaticQuestionManager.swift */; };
-		AEFD01E02AE033E9001D2C30 /* ChatBubbles.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFD01DF2AE033E9001D2C30 /* ChatBubbles.swift */; };
+		AEEA8DCF2AEB82070068550E /* SelectQuestionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEA8DCE2AEB82070068550E /* SelectQuestionViewModel.swift */; };
+		AEEA8DD12AEB82290068550E /* SelectQuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEA8DD02AEB82290068550E /* SelectQuestionView.swift */; };
+		AEEA8DD32AEB82520068550E /* ChatBubbles.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEA8DD22AEB82520068550E /* ChatBubbles.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -109,11 +109,11 @@
 		3D4412612AE509C600FD5A51 /* MyAccountConnectingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyAccountConnectingViewModel.swift; sourceTree = "<group>"; };
 		3D4412632AE50E8E00FD5A51 /* MyAccountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyAccountViewModel.swift; sourceTree = "<group>"; };
 		3D44126A2AE6246100FD5A51 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		3D4412772AE9F5E600FD5A51 /* ServiceWebURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceWebURL.swift; sourceTree = "<group>"; };
 		3D4412792AEAB34000FD5A51 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		3D44127B2AEAC3C000FD5A51 /* ConnectedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedView.swift; sourceTree = "<group>"; };
 		3D44127D2AEAC57500FD5A51 /* ConnectionWaypointView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionWaypointView.swift; sourceTree = "<group>"; };
 		3D44127F2AEACA2A00FD5A51 /* ConnectionWaypointViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionWaypointViewModel.swift; sourceTree = "<group>"; };
-		3D4412772AE9F5E600FD5A51 /* ServiceWebURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceWebURL.swift; sourceTree = "<group>"; };
 		3DB6A5AA2AE0C09800C1369F /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		3DB6A5AD2AE0C12B00C1369F /* AppleLoginButtonViewRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginButtonViewRepresentable.swift; sourceTree = "<group>"; };
 		3DB6A5B02AE11C2D00C1369F /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
@@ -138,7 +138,6 @@
 		AE2BB5FE2AD673890003CD85 /* LoginMD.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = LoginMD.md; sourceTree = "<group>"; };
 		AE2BB6022AD674D40003CD85 /* TabBarMD.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = TabBarMD.md; sourceTree = "<group>"; };
 		AE5693242AEAD982009F3400 /* AnswerWriteViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnswerWriteViewModel.swift; sourceTree = "<group>"; };
-		AE66978D2AE8FC100004B56C /* SelectQuestionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectQuestionViewModel.swift; sourceTree = "<group>"; };
 		AE66978F2AE904F80004B56C /* AnswerWriteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerWriteView.swift; sourceTree = "<group>"; };
 		AE6ACF542AE0B49E0017088C /* Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
 		AE7EE4DD2AD6409000E0A573 /* ABloom.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ABloom.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -153,11 +152,12 @@
 		AE8D3C5D2ADE1A22009899A7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		AE8D3C602ADE3C73009899A7 /* Ex+Shape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ex+Shape.swift"; sourceTree = "<group>"; };
 		AEAB19362ADF77210057BC43 /* Buttons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Buttons.swift; sourceTree = "<group>"; };
-		AEB502612AE5F5340056E439 /* SelectQuestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectQuestionView.swift; sourceTree = "<group>"; };
 		AEB502632AE5FA840056E439 /* CustomNavigationBarModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNavigationBarModifier.swift; sourceTree = "<group>"; };
 		AEB5026A2AE64B8D0056E439 /* CategoryQuestionBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryQuestionBox.swift; sourceTree = "<group>"; };
 		AEC260602AEA5A8000DF7CD5 /* StaticQuestionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticQuestionManager.swift; sourceTree = "<group>"; };
-		AEFD01DF2AE033E9001D2C30 /* ChatBubbles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatBubbles.swift; sourceTree = "<group>"; };
+		AEEA8DCE2AEB82070068550E /* SelectQuestionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectQuestionViewModel.swift; sourceTree = "<group>"; };
+		AEEA8DD02AEB82290068550E /* SelectQuestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectQuestionView.swift; sourceTree = "<group>"; };
+		AEEA8DD22AEB82520068550E /* ChatBubbles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatBubbles.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -367,8 +367,8 @@
 			children = (
 				AE1AE9F82AE50BBC0010089F /* QuestionMainView.swift */,
 				AE1AE9FE2AE557E00010089F /* AnswerCheckView.swift */,
-				AEB502612AE5F5340056E439 /* SelectQuestionView.swift */,
 				AE66978F2AE904F80004B56C /* AnswerWriteView.swift */,
+				AEEA8DD02AEB82290068550E /* SelectQuestionView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -378,7 +378,7 @@
 			children = (
 				AE5693242AEAD982009F3400 /* AnswerWriteViewModel.swift */,
 				AE1AEA002AE55A0C0010089F /* QuestionMainViewModel.swift */,
-				AE66978D2AE8FC100004B56C /* SelectQuestionViewModel.swift */,
+				AEEA8DCE2AEB82070068550E /* SelectQuestionViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -397,13 +397,13 @@
 		AE2BB5F72AD66C0F0003CD85 /* Components */ = {
 			isa = PBXGroup;
 			children = (
-				6053F1612ADF6CDE0064A6E0 /* InputFieldModifier.swift */,
-				6053F1752AE899320064A6E0 /* InputFields.swift */,
 				AEAB19362ADF77210057BC43 /* Buttons.swift */,
-				AEFD01DF2AE033E9001D2C30 /* ChatBubbles.swift */,
-				AE1AE9FA2AE51BF00010089F /* QnAListItem.swift */,
-				AEB502632AE5FA840056E439 /* CustomNavigationBarModifier.swift */,
 				AEB5026A2AE64B8D0056E439 /* CategoryQuestionBox.swift */,
+				AEEA8DD22AEB82520068550E /* ChatBubbles.swift */,
+				AEB502632AE5FA840056E439 /* CustomNavigationBarModifier.swift */,
+				6053F1752AE899320064A6E0 /* InputFields.swift */,
+				6053F1612ADF6CDE0064A6E0 /* InputFieldModifier.swift */,
+				AE1AE9FA2AE51BF00010089F /* QnAListItem.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -425,13 +425,6 @@
 				605541162ADE1ACF00AD5625 /* Tab.swift */,
 			);
 			path = TabBar;
-			sourceTree = "<group>";
-		};
-		AE5EFD2A2AEACD9100D48397 /* New Group */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = "New Group";
 			sourceTree = "<group>";
 		};
 		AE7EE4D42AD6409000E0A573 = {
@@ -512,7 +505,6 @@
 		AEB502672AE61D5E0056E439 /* CoreViews */ = {
 			isa = PBXGroup;
 			children = (
-				AE5EFD2A2AEACD9100D48397 /* New Group */,
 				AE2BB6012AD674630003CD85 /* TabBar */,
 				AE2BB5FF2AD673CC0003CD85 /* Home */,
 				AE1AE9F52AE50B440010089F /* QnA */,
@@ -671,22 +663,21 @@
 				6053F16E2AE179240064A6E0 /* HomeView.swift in Sources */,
 				AE8D3C512ADE19E0009899A7 /* Ex+Font.swift in Sources */,
 				AE8D3C612ADE3C73009899A7 /* Ex+Shape.swift in Sources */,
+				AEEA8DD32AEB82520068550E /* ChatBubbles.swift in Sources */,
 				6053F15B2ADEB7700064A6E0 /* RegistrationViewModel.swift in Sources */,
 				6055411A2ADE66B000AD5625 /* RegistrationView.swift in Sources */,
 				6053F1762AE899320064A6E0 /* InputFields.swift in Sources */,
 				AE1AE9FB2AE51BF00010089F /* QnAListItem.swift in Sources */,
 				AE8D3C512ADE19E0009899A7 /* Ex+Font.swift in Sources */,
-				AEB502622AE5F5340056E439 /* SelectQuestionView.swift in Sources */,
 				AEB5026B2AE64B8D0056E439 /* CategoryQuestionBox.swift in Sources */,
+				AEEA8DD12AEB82290068550E /* SelectQuestionView.swift in Sources */,
 				AE8D3C612ADE3C73009899A7 /* Ex+Shape.swift in Sources */,
 				AE6697902AE904F80004B56C /* AnswerWriteView.swift in Sources */,
 				3D44125A2AE4F8B600FD5A51 /* WebView.swift in Sources */,
 				3D4412602AE503FD00FD5A51 /* ToastView.swift in Sources */,
 				AEB502642AE5FA840056E439 /* CustomNavigationBarModifier.swift in Sources */,
-				AEFD01E02AE033E9001D2C30 /* ChatBubbles.swift in Sources */,
 				6053F15B2ADEB7700064A6E0 /* RegistrationViewModel.swift in Sources */,
 				3D4412582AE4F71000FD5A51 /* PolicyView.swift in Sources */,
-				AE66978E2AE8FC100004B56C /* SelectQuestionViewModel.swift in Sources */,
 				6053F1712AE17A260064A6E0 /* HomeRecommendView.swift in Sources */,
 				6055411A2ADE66B000AD5625 /* RegistrationView.swift in Sources */,
 				AEAB19372ADF77210057BC43 /* Buttons.swift in Sources */,
@@ -694,6 +685,7 @@
 				3D44125C2AE4F91900FD5A51 /* EmbedWebView.swift in Sources */,
 				3D44127E2AEAC57500FD5A51 /* ConnectionWaypointView.swift in Sources */,
 				AE7EE4E12AD6409000E0A573 /* ABloomApp.swift in Sources */,
+				AEEA8DCF2AEB82070068550E /* SelectQuestionViewModel.swift in Sources */,
 				3D44125E2AE4FB7400FD5A51 /* MyAccountConnectingView.swift in Sources */,
 				3DB6A5B12AE11C2D00C1369F /* LoginViewModel.swift in Sources */,
 				3DB6A5AE2AE0C12B00C1369F /* AppleLoginButtonViewRepresentable.swift in Sources */,
@@ -713,7 +705,6 @@
 				605541172ADE1ACF00AD5625 /* Tab.swift in Sources */,
 				3D4412432AE388DB00FD5A51 /* UserManager.swift in Sources */,
 				3D44127C2AEAC3C000FD5A51 /* ConnectedView.swift in Sources */,
-				AEFEF18A2AEA03E2000DB253 /* AnswerWriteViewModel.swift in Sources */,
 				AE6ACF552AE0B49E0017088C /* Helpers.swift in Sources */,
 				AE5693252AEAD982009F3400 /* AnswerWriteViewModel.swift in Sources */,
 				AE1AE9F92AE50BBC0010089F /* QuestionMainView.swift in Sources */,
@@ -863,6 +854,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -895,6 +887,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerCheckView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerCheckView.swift
@@ -15,17 +15,16 @@ struct AnswerCheckView: View {
   
   var body: some View {
     VStack {
-      // MARK: Header
+      
       CategoryQuestionBox(
         question: "반려동물을 기르고 싶어?",
         category: "경제 질문",
         categoryImg: "squareIcon_isometric_health"
       )
+      .padding(.vertical, 30)
       
       Spacer()
-        .frame(height: 40)
-      
-      // MARK: Content
+        .frame(height: 10)
       
       // TODO: 데이터의 타임 스탬프를 비교하여, 먼저 작성한 답변이 위로 보여야 함
       VStack(spacing: 20) {
@@ -47,11 +46,9 @@ struct AnswerCheckView: View {
         Spacer()
       }
       .padding(.horizontal, 20)
-      .frame(maxWidth: .infinity, maxHeight: .infinity)
       .background(backWall())
     }
     
-    // MARK: NavigationBar
     .customNavigationBar(
       centerView: {
         Text("우리의 문답")

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/QuestionMainView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/QuestionMainView.swift
@@ -15,39 +15,12 @@ struct QuestionMainView: View {
     
     NavigationStack {
       VStack {
-        
-        // 헤더
-        HStack {
-          Text("우리의 문답")
-            .fontWithTracking(.title3Bold)
-            .padding([.leading], 20)
-          Spacer()
-          // FIXME: 다른 뷰로 전환 시에는 다른 방식으로 처리해야함
-          NavigationLink(value: 0) {
-            Image("pencil_write_fill")
-              .padding([.trailing], 17)
-          }
-        }
-        .padding([.top], 20)
-        .foregroundStyle(.stone700)
+        headerView
         
         Spacer()
           .frame(height: 34)
         
-        // 질문 목록
-        ScrollView(.vertical) {
-          LazyVStack(spacing: 30) {
-            Spacer()
-              .frame(height: 0)
-            ForEach(1..<10) { num in
-              NavigationLink(value: num) {
-                
-                // TODO: 해당 정보란을 데이터로 가져와야함
-                QnAListItem(categoryImg: "squareIcon_isometric_sofa", question: "나와 결혼을 결심한 순간은 언제야?\(num)", date: "2023년 9월 18일", isAns: false)
-              }
-            }
-          }
-        }
+        answeredQScroll
         
         .navigationDestination(for: Int.self, destination: { content in
           if content == 0 {
@@ -56,12 +29,47 @@ struct QuestionMainView: View {
             AnswerCheckView(num: content)
           }
         })
-        
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(backWall())
       }
       .background(backgroundDefault())
     }
+  }
+}
+
+extension QuestionMainView {
+  private var headerView: some View {
+    // 헤더
+    HStack {
+      Text("우리의 문답")
+        .fontWithTracking(.title3Bold)
+        .padding([.leading], 20)
+      Spacer()
+      // FIXME: 다른 뷰로 전환 시에는 다른 방식으로 처리해야함
+      NavigationLink(value: 0) {
+        Image("pencil_write_fill")
+          .padding([.trailing], 17)
+      }
+    }
+    .padding([.top], 20)
+    .foregroundStyle(.stone700)
+  }
+  
+  private var answeredQScroll: some View {
+    // 질문 목록
+    ScrollView(.vertical) {
+      LazyVStack(spacing: 30) {
+        Spacer()
+          .frame(height: 0)
+        ForEach(1..<3) { num in
+          NavigationLink(value: num) {
+            
+            // TODO: 해당 정보란을 데이터로 가져와야함
+            QnAListItem(categoryImg: "squareIcon_isometric_sofa", question: "나와 결혼을 결심한 순간은 언제야?\(num)", date: "2023년 9월 18일", isAns: false)
+          }
+        }
+      }
+    }
+    
   }
 }
 

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/QuestionMainView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/QuestionMainView.swift
@@ -47,8 +47,8 @@ extension QuestionMainView {
       // FIXME: 다른 뷰로 전환 시에는 다른 방식으로 처리해야함
       NavigationLink(value: 0) {
         Image("pencil_write_fill")
-          .padding([.trailing], 17)
       }
+      .padding([.trailing], 17)
     }
     .padding([.top], 20)
     .foregroundStyle(.stone700)

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/SelectQuestionView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/SelectQuestionView.swift
@@ -71,7 +71,7 @@ extension SelectQuestionView {
         }
       }
       .padding([.horizontal, .bottom], 22)
-      .padding(.top, 30)
+      .padding(.top, 36)
       
     }
   }
@@ -94,9 +94,9 @@ extension SelectQuestionView {
         ForEach(selectQVM.filteredLists, id: \.self) { question in
           NavigationLink(value: question) {
             LeftBlueChatBubble(text: question.content)
-              .padding(.horizontal, 20)
-              .padding(.bottom, 12)
           }
+          .padding(.horizontal, 20)
+          .padding(.bottom, 12)
         }
       }
     }

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/SelectQuestionView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/SelectQuestionView.swift
@@ -23,6 +23,7 @@ struct SelectQuestionView: View {
         })
         .background(backWall())
     }
+    
     .task {
       try? await selectQVM.fetchQuestions()
     }
@@ -43,8 +44,9 @@ struct SelectQuestionView: View {
       rightView: {
         EmptyView()
       })
-    // 배경화면
+    
     .background(backgroundDefault())
+    .ignoresSafeArea(.all, edges: .bottom)
   }
 }
 
@@ -68,13 +70,15 @@ extension SelectQuestionView {
           })
         }
       }
-      .padding(.horizontal, 22)
-      .padding(.vertical, 15)
+      .padding([.horizontal, .bottom], 22)
+      .padding(.top, 30)
+      
     }
   }
   
   private var questionListView: some View {
     VStack(spacing: 0) {
+
       HStack {
         Text("\(selectQVM.selectedCategory.type) 문답")
           .fontWithTracking(.headlineR)
@@ -86,16 +90,15 @@ extension SelectQuestionView {
       .padding(.top, 34)
       .padding(.bottom, 26)
       
-      ScrollView {
+      ScrollView(.vertical) {
         ForEach(selectQVM.filteredLists, id: \.self) { question in
           NavigationLink(value: question) {
             LeftBlueChatBubble(text: question.content)
-              .padding(.bottom, 12)
               .padding(.horizontal, 20)
+              .padding(.bottom, 12)
           }
         }
       }
-      Spacer()
     }
   }
 }

--- a/ABloom/ABloom/Resources/Components/CustomNavigationBarModifier.swift
+++ b/ABloom/ABloom/Resources/Components/CustomNavigationBarModifier.swift
@@ -46,6 +46,7 @@ struct CustomNavigationBarModifier<C, L, R>: ViewModifier where C: View, L: View
       
       Spacer()
     }
+    .padding(.vertical, 10)
     .navigationBarBackButtonHidden(true)
   }
 }

--- a/ABloom/ABloom/Resources/Components/CustomNavigationBarModifier.swift
+++ b/ABloom/ABloom/Resources/Components/CustomNavigationBarModifier.swift
@@ -46,7 +46,7 @@ struct CustomNavigationBarModifier<C, L, R>: ViewModifier where C: View, L: View
       
       Spacer()
     }
-    .padding(.vertical, 10)
+    .padding(.top, 10)
     .navigationBarBackButtonHidden(true)
   }
 }

--- a/ABloom/ABloom/Resources/Components/QnAListItem.swift
+++ b/ABloom/ABloom/Resources/Components/QnAListItem.swift
@@ -15,44 +15,45 @@ struct QnAListItem: View {
   
   var body: some View {
     HStack(spacing: 0) {
-      // TODO: 이미지 쉐도우 확인
+      
       Image(categoryImg)
         .resizable()
-        .frame(width: 50, height: 50)
         .aspectRatio(contentMode: .fit)
-        .overlay(
-          RoundedRectangle(cornerRadius: 36)
-            .clayMorpMDShadow()
-            .foregroundStyle(.clear)
-            .frame(width: 50, height: 50)
-        )
         .frame(width: 50, height: 50)
+        .background(
+          RoundedRectangle(cornerRadius: 17)
+            .clayMorpMDShadow()
+            .foregroundStyle(.white)
+        )
         .padding(.trailing, 15)
-      
       
       VStack(spacing: 4) {
         HStack {
           Text(question)
             .fontWithTracking(.caption1Bold)
             .foregroundStyle(.black)
+          
           Spacer()
         }
+        
         HStack {
           Text(date)
             .fontWithTracking(.caption2R)
+          
           Spacer()
+          
           Text(isAns ? "" : "답변을 기다리고 있어요 >")
             .fontWithTracking(.caption2R)
         }
         .foregroundStyle(.stone500)
+        
       }
       Spacer()
-      
     }
     .padding([.leading, .trailing], 20)
   }
 }
 
 #Preview {
-  QnAListItem(categoryImg: "squareIcon_isometric_sofa", question: "나와 결혼을 결심한 순간은 언제야?", date: "2023년 9월 18일", isAns: false)
+  QnAListItem(categoryImg: "squareIcon_isometric_health", question: "나와 결혼을 결심한 순간은 언제야?", date: "2023년 9월 18일", isAns: false)
 }

--- a/ABloom/ABloom/Resources/Components/QnAListItem.swift
+++ b/ABloom/ABloom/Resources/Components/QnAListItem.swift
@@ -50,7 +50,7 @@ struct QnAListItem: View {
       }
       Spacer()
     }
-    .padding([.leading, .trailing], 20)
+    .padding(.horizontal, 20)
   }
 }
 

--- a/ABloom/ABloom/Resources/Extensions/Ex+Shape.swift
+++ b/ABloom/ABloom/Resources/Extensions/Ex+Shape.swift
@@ -41,14 +41,17 @@ extension Shape {
    - radius = radius / 2
    - 실행시켜보고 다르게 보인다면 최대한 비슷하도록 수치 조정
    */
+  
+  // 완료
   public func clayMorpMDShadow() -> some View {
     self.fill(
       .shadow(.inner(color: Color.black.opacity(0.36), radius: 5, x: 0, y: -3))
       .shadow(.inner(color: Color.white.opacity(0.5), radius: 7.5, x: 3, y: 1))
-      .shadow(.drop(color: Color.black.opacity(0.03), radius: 20, x: 0, y: 7))
+      .shadow(.drop(color: Color.black.opacity(0.03), radius: 10, x: 0, y: 7))
     )
   }
   
+  // 사용 X
   public func clayMorpXLShadow() -> some View {
     self.fill(
       .shadow(.inner(color: Color.black.opacity(0.03), radius: 10, x: 0, y: -3))
@@ -65,6 +68,7 @@ extension Shape {
     )
   }
   
+  // 완료
   public func glassBG1Shadow() -> some View {
     self.fill(
       .shadow(.drop(color: Color.black.opacity(0.1), radius: 12.5, x: 0, y: 4))
@@ -72,6 +76,7 @@ extension Shape {
     .background(blur(radius: 60))
   }
   
+  // 사용 X - 버튼 컴포넌트에서 활용
   public func clayMorpMDPinkShadow() -> some View {
     self.fill(
       .shadow(.inner(color: Color.black.opacity(0.03), radius: 10, x: 0, y: -3))
@@ -80,6 +85,7 @@ extension Shape {
     )
   }
   
+  // 사용 X - 버튼 컴포넌트에서 활용
   public func clayMorpBtnXLPinkShadow() -> some View {
     self.fill(
       .shadow(.inner(color: Color.black.opacity(0.03), radius: 10, x: 0, y: -3))
@@ -88,6 +94,7 @@ extension Shape {
     )
   }
   
+  // 완료 - 버튼 컴포넌트에서 활용
   public func clayMorpBtnGrayShadow() -> some View {
     self.fill(
       .shadow(.inner(color: Color.black.opacity(0.08), radius: 5, x: 0, y: -3))
@@ -96,6 +103,7 @@ extension Shape {
     .shadow(color: Color.stone200.opacity(1), radius: 20, x: 0, y: 20)
   }
   
+  // 완료 - 버튼 컴포넌트에서 활용
   public func clayMorpBtnXLPurpleShadow() -> some View {
     self.fill(
       .shadow(.inner(color: Color.black.opacity(0.3), radius: 5, x: 0, y: -3))
@@ -104,6 +112,7 @@ extension Shape {
     .shadow(color: Color.purple200.opacity(1), radius: 20, x: 0, y: 20)
   }
   
+  // 완료
   public func loginChatBubbleShadow() -> some View {
     self.fill(
       .shadow(.inner(color: Color.black.opacity(0.06), radius: 5, x: 0, y: -3))

--- a/ABloom/ABloom/Resources/Extensions/Ex+Shape.swift
+++ b/ABloom/ABloom/Resources/Extensions/Ex+Shape.swift
@@ -7,6 +7,16 @@
 
 import SwiftUI
 
+extension Color {
+  public func exampleShadow() -> some ShapeStyle {
+    self
+      .shadow(.inner(color: Color.black.opacity(0.15), radius: 10, x: 0, y: -3))
+      .shadow(.inner(color: Color.white.opacity(0.25), radius: 15, x: 3, y: 1))
+      .shadow(.drop(color: Color.black.opacity(0.015), radius: 20, x: 0, y: 7))
+  }
+  
+}
+
 extension Shape {
   
   /***
@@ -29,13 +39,12 @@ extension Shape {
    
    피그마와 다르게 적용할 점
    - radius = radius / 2
-   - drop은 self.fill()에 외부에 작성
    - 실행시켜보고 다르게 보인다면 최대한 비슷하도록 수치 조정
    */
   public func clayMorpMDShadow() -> some View {
     self.fill(
-      .shadow(.inner(color: Color.black.opacity(0.03), radius: 10, x: 0, y: -3))
-      .shadow(.inner(color: Color.white.opacity(0.5), radius: 15, x: 3, y: 1))
+      .shadow(.inner(color: Color.black.opacity(0.36), radius: 5, x: 0, y: -3))
+      .shadow(.inner(color: Color.white.opacity(0.5), radius: 7.5, x: 3, y: 1))
       .shadow(.drop(color: Color.black.opacity(0.03), radius: 20, x: 0, y: 7))
     )
   }
@@ -58,9 +67,9 @@ extension Shape {
   
   public func glassBG1Shadow() -> some View {
     self.fill(
-      .shadow(.drop(color: Color.black.opacity(0.05), radius: 12.5, x: 0, y: 4))
+      .shadow(.drop(color: Color.black.opacity(0.1), radius: 12.5, x: 0, y: 4))
     )
-    .blur(radius: 1)
+    .background(blur(radius: 60))
   }
   
   public func clayMorpMDPinkShadow() -> some View {

--- a/ABloom/ABloom/Resources/Extensions/Ex+View.swift
+++ b/ABloom/ABloom/Resources/Extensions/Ex+View.swift
@@ -98,33 +98,28 @@ extension View {
     RoundedRectangle(cornerRadius: 20)
       .glassBG1Shadow()
       .foregroundStyle(glassGradient())
-      .ignoresSafeArea()
   }
   
   /**
    Custom Font
    - 모든 Text는 자간이 1 혹은 -0.4 이므로 아래의 Modifier에 value가 1 혹은 -0.4로 적용되어야 함
-   
-   사용예제
-   -
-   .fontWithTracking(fontStyle: .largeTitleBold, value: 1)
    */
-  func fontWithTracking(_ fontStyle: Font, tracking: CGFloat = 1) -> some View {
+  func fontWithTracking(_ fontStyle: Font, tracking: CGFloat = 1, lineSpacing: CGFloat = 5) -> some View {
     self
       .font(fontStyle)
-      .lineSpacing(5)
+      .lineSpacing(lineSpacing)
       .tracking(tracking)
   }
   
   /// textField Placeholder customize
   func placeholder<Content: View>(
-          when shouldShow: Bool,
-          alignment: Alignment = .leading,
-          @ViewBuilder placeholder: () -> Content) -> some View {
-
-          ZStack(alignment: alignment) {
-              placeholder().opacity(shouldShow ? 1 : 0)
-              self
-          }
+    when shouldShow: Bool,
+    alignment: Alignment = .leading,
+    @ViewBuilder placeholder: () -> Content) -> some View {
+      
+      ZStack(alignment: alignment) {
+        placeholder().opacity(shouldShow ? 1 : 0)
+        self
       }
+    }
 }


### PR DESCRIPTION
#### close #59

### ✏️ 개요
- Question 탭에 연결되어 있는 3개의 뷰 디자인 수정 (WriteView는 이전에 수정함)

### 💻 작업 사항
- [X] QuestionMainView에서 비치되는 이미지 세도우 값 조정 (벤틀리와 차후 논의 필요)
- [X] SelectQuestionView에서 backWall 전체 화면으로 조정, padding 값 조정
- [X] AnswerCheckView에서 padding 값 조정
- [x] backWall에 해당하는 blur 값 조절하여 피그마와 어느정도 맞춤
- [X] Customized Navigation에 패딩(10) 추가 (피그마에서 값이 10)
- [X] 폰트 모디파이어에서 라인 스페이싱 파라미터 추가
- [X] [Bug] New Group에 해당하는 코드 삭제

### 📄 리뷰 노트
컴포넌트는 우선 제가 사용하는 뷰에서 조절하였습니다. 
다음 이슈 때는 챗 버블과 쉐도우 포함 전반적인 컴포넌트를 수정하도록 하겠습니다. :)

Bentley -> 이미지에 inner shadow를 덮는 과정을 완료하지 못했습니다. 이미지 자체 배경 칼라에 쉐도우를 입히기 위해서 여러방법으로 시도했지만 찾지 못해 다른 방안을 모색, 지금 shadow로 지정, 혹은 둘 사이의 합의점을 찾으면 좋을 것 같습니다.

### 📱결과 화면(optional)
| Main | Question | AnswerCheck |
|--------|--------|--------|
| ![Main](https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/44897331/53145c7a-539d-48bd-95eb-7f5925cd678b) | ![Question](https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/44897331/23f7ea7c-cce2-4abc-bbff-c25f91a5bcb2) | ![Check](https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/44897331/b2eef301-b528-4250-8db1-d6e0afce047c) |
 
### 📚 ETC(optional)
X
