### PR TITLE
[Feat/#69] 내 정보 수정 구현

### DIFF
--- a/ABloom/ABloom/Firebase/Firestore/UserManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/UserManager.swift
@@ -93,7 +93,12 @@ final class UserManager {
   }
   
   func updateUserName(userId: String, name: String) throws {
-    let data: [String:Any] = [DBUser.CodingKeys.name.rawValue : name]
+    let data: [String: Any] = [DBUser.CodingKeys.name.rawValue:name]
+    userDocument(userId: userId).updateData(data)
+  }
+  
+  func updateMarriageDate(userId: String, date: Date) throws {
+    let data: [String: Any] = [DBUser.CodingKeys.estimatedMarriageDate.rawValue:date]
     userDocument(userId: userId).updateData(data)
   }
   

--- a/ABloom/ABloom/Firebase/Firestore/UserManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/UserManager.swift
@@ -92,6 +92,11 @@ final class UserManager {
     try userDocument(userId: user.userId).setData(from: user, merge: false)
   }
   
+  func updateUserName(userId: String, name: String) throws {
+    let data: [String:Any] = [DBUser.CodingKeys.name.rawValue : name]
+    userDocument(userId: userId).updateData(data)
+  }
+  
   func connectFiance(connectionCode: String) async throws {
     let snapshot = try await userCollection.whereField(DBUser.CodingKeys.invitationCode.rawValue, isEqualTo: connectionCode).getDocuments()
     

--- a/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountView.swift
@@ -66,8 +66,6 @@ extension MyAccountView {
           .foregroundStyle(.stone800)
         HStack {
           Text("결혼까지 D-\(myAccountVM.dDay ?? 0)")
-            .fontWithTracking(.footnoteR)
-            .foregroundStyle(.stone500)
           
           Spacer()
           
@@ -75,10 +73,9 @@ extension MyAccountView {
             myAccountVM.showActionSheet = true
           } label: {
             Text("정보 수정하기 >")
-              .fontWithTracking(.footnoteR)
-              .foregroundStyle(.stone500)
           }
         }
+        .fontWithTracking(.footnoteR)
         .foregroundStyle(.stone500)
       }
     }
@@ -106,7 +103,7 @@ extension MyAccountView {
     }
     // 결혼 날짜 변경 모달
     .sheet(isPresented: $myAccountVM.showDatePicker) {
-      DatePicker("", selection: $myAccountVM.merriageDate, displayedComponents: .date)
+      DatePicker("", selection: $myAccountVM.marriageDate, displayedComponents: .date)
         .datePickerStyle(.graphical)
         .frame(width: 320)
         .labelsHidden()
@@ -114,7 +111,7 @@ extension MyAccountView {
       
       Button {
         Task {
-          try? myAccountVM.updateMyMarriageDate(date: myAccountVM.merriageDate)
+          try? myAccountVM.updateMyMarriageDate(date: myAccountVM.marriageDate)
           try? await myAccountVM.getMyInfo()
           myAccountVM.showDatePicker = false
         }

--- a/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountView.swift
@@ -84,6 +84,7 @@ extension MyAccountView {
     }
     // 이름 변경 Alert
     .alert("이름 변경하기", isPresented: $myAccountVM.showNameChangeAlert) {
+      // TODO: 버튼 UI 수정
       TextField(text: $myAccountVM.nameChangeTextfield) {
         Text("홍길동")
       }
@@ -94,7 +95,7 @@ extension MyAccountView {
         Text("취소")
       }
       
-      Button("확인", role: .cancel) {
+      Button("확인") {
         Task {
           try? myAccountVM.updateMyName(name: myAccountVM.nameChangeTextfield)
           try? await myAccountVM.getMyInfo()
@@ -129,16 +130,25 @@ extension MyAccountView {
         .fontWithTracking(.headlineBold)
       
       MenuListButtonItem(title: "로그아웃") {
-        do {
-          try myAccountVM.signOut()
-        } catch {
-          print(error.localizedDescription)
-        }
+        myAccountVM.showSignOutCheckAlert = true
       }
       
       MenuListNavigationItem(title: "회원탈퇴") {
         Text("회원탈퇴")
       }
+    }
+    .alert("로그아웃 하시겠어요?", isPresented: $myAccountVM.showSignOutCheckAlert) {
+      // TODO: 버튼 UI 수정
+      Button("취소") {
+        myAccountVM.showSignOutCheckAlert = false
+      }
+      
+      Button("로그아웃") {
+        try? myAccountVM.signOut()
+        myAccountVM.showSignOutCheckAlert = false
+      }
+    } message: {
+      Text("다시 로그인해도 정보가 유지되니\n안심하고 로그아웃하셔도 돼요.")
     }
   }
 }

--- a/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountView.swift
@@ -29,6 +29,43 @@ struct MyAccountView: View {
     .navigationBarTitleDisplayMode(.inline)
     .padding(.horizontal, 25)
     .background(backgroundDefault())
+    .confirmationDialog("정보 변경", isPresented: $myAccountVM.showActionSheet, titleVisibility: .hidden) {
+      Button("이름 변경하기", role: .none) {
+        myAccountVM.showNameChangeAlert = true
+      }
+      
+      Button("결혼예정일 수정하기", role: .none) {
+        
+      }
+      
+      Button("취소", role: .cancel) {
+        myAccountVM.showActionSheet = false
+      }
+    }
+    .alert("이름 변경하기", isPresented: $myAccountVM.showNameChangeAlert) {
+      TextField(text: $myAccountVM.nameChangeTextfield) {
+        Text("홍길동")
+      }
+      
+      Button {
+        myAccountVM.showNameChangeAlert = false
+      } label: {
+        Text("취소")
+      }
+      
+      Button {
+        Task {
+          try? myAccountVM.updateMyName(name: myAccountVM.nameChangeTextfield)
+          try? await myAccountVM.getMyInfo()
+        }
+      } label: {
+        Text("확인")
+      }
+      
+    } message: {
+      Text("변경할 이름을 입력해주세요.")
+    }
+
   }
 }
 
@@ -57,9 +94,13 @@ extension MyAccountView {
           
           Spacer()
           
-          Text("정보 수정하기 >")
-            .fontWithTracking(.footnoteR)
-            .foregroundStyle(.stone500)
+          Button {
+            myAccountVM.showActionSheet = true
+          } label: {
+            Text("정보 수정하기 >")
+              .fontWithTracking(.footnoteR)
+              .foregroundStyle(.stone500)
+          }
         }
         .foregroundStyle(.stone500)
       }

--- a/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountView.swift
@@ -35,37 +35,14 @@ struct MyAccountView: View {
       }
       
       Button("결혼예정일 수정하기", role: .none) {
-        
+        myAccountVM.showDatePicker = true
       }
       
       Button("취소", role: .cancel) {
         myAccountVM.showActionSheet = false
       }
     }
-    .alert("이름 변경하기", isPresented: $myAccountVM.showNameChangeAlert) {
-      TextField(text: $myAccountVM.nameChangeTextfield) {
-        Text("홍길동")
-      }
-      
-      Button {
-        myAccountVM.showNameChangeAlert = false
-      } label: {
-        Text("취소")
-      }
-      
-      Button {
-        Task {
-          try? myAccountVM.updateMyName(name: myAccountVM.nameChangeTextfield)
-          try? await myAccountVM.getMyInfo()
-        }
-      } label: {
-        Text("확인")
-      }
-      
-    } message: {
-      Text("변경할 이름을 입력해주세요.")
-    }
-
+    .tint(.purple600)
   }
 }
 
@@ -103,6 +80,45 @@ extension MyAccountView {
           }
         }
         .foregroundStyle(.stone500)
+      }
+    }
+    // 이름 변경 Alert
+    .alert("이름 변경하기", isPresented: $myAccountVM.showNameChangeAlert) {
+      TextField(text: $myAccountVM.nameChangeTextfield) {
+        Text("홍길동")
+      }
+      
+      Button {
+        myAccountVM.showNameChangeAlert = false
+      } label: {
+        Text("취소")
+      }
+      
+      Button("확인", role: .cancel) {
+        Task {
+          try? myAccountVM.updateMyName(name: myAccountVM.nameChangeTextfield)
+          try? await myAccountVM.getMyInfo()
+        }
+      }
+    } message: {
+      Text("변경할 이름을 입력해주세요.")
+    }
+    // 결혼 날짜 변경 모달
+    .sheet(isPresented: $myAccountVM.showDatePicker) {
+      DatePicker("", selection: $myAccountVM.merriageDate, displayedComponents: .date)
+        .datePickerStyle(.graphical)
+        .frame(width: 320)
+        .labelsHidden()
+        .presentationDetents([.medium])
+      
+      Button {
+        Task {
+          try? myAccountVM.updateMyMarriageDate(date: myAccountVM.merriageDate)
+          try? await myAccountVM.getMyInfo()
+          myAccountVM.showDatePicker = false
+        }
+      } label: {
+        Text("완료")
       }
     }
   }

--- a/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountView.swift
@@ -53,11 +53,13 @@ extension MyAccountView {
         HStack {
           Text("결혼까지 D-\(myAccountVM.dDay ?? 0)")
             .fontWithTracking(.footnoteR)
+            .foregroundStyle(.stone500)
           
           Spacer()
           
           Text("정보 수정하기 >")
             .fontWithTracking(.footnoteR)
+            .foregroundStyle(.stone500)
         }
         .foregroundStyle(.stone500)
       }

--- a/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountViewModel.swift
@@ -11,6 +11,9 @@ import Foundation
 final class MyAccountViewModel: ObservableObject {
   @Published var userName: String?
   @Published var dDay: Int?
+  @Published var showActionSheet: Bool = false
+  @Published var showNameChangeAlert: Bool = false
+  @Published var nameChangeTextfield: String = ""
   
   func signOut() throws {
     try AuthenticationManager.shared.signOut()
@@ -22,6 +25,11 @@ final class MyAccountViewModel: ObservableObject {
     
     self.userName = user.name
     self.dDay = calculateDDay(estimatedMarriageDate: user.estimatedMarriageDate ?? .now)
+  }
+  
+  func updateMyName(name: String) throws {
+    let myId: String = try AuthenticationManager.shared.getAuthenticatedUser().uid
+    try UserManager.shared.updateUserName(userId: myId, name: name)
   }
   
   private func calculateDDay(estimatedMarriageDate: Date) -> Int {

--- a/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountViewModel.swift
@@ -16,6 +16,7 @@ final class MyAccountViewModel: ObservableObject {
   @Published var nameChangeTextfield: String = ""
   @Published var showDatePicker: Bool = false
   @Published var merriageDate: Date = .now
+  @Published var showSignOutCheckAlert: Bool = false
   
   func signOut() throws {
     try AuthenticationManager.shared.signOut()

--- a/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountViewModel.swift
@@ -15,7 +15,7 @@ final class MyAccountViewModel: ObservableObject {
   @Published var showNameChangeAlert: Bool = false
   @Published var nameChangeTextfield: String = ""
   @Published var showDatePicker: Bool = false
-  @Published var merriageDate: Date = .now
+  @Published var marriageDate: Date = .now
   @Published var showSignOutCheckAlert: Bool = false
   
   func signOut() throws {

--- a/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountViewModel.swift
@@ -14,6 +14,8 @@ final class MyAccountViewModel: ObservableObject {
   @Published var showActionSheet: Bool = false
   @Published var showNameChangeAlert: Bool = false
   @Published var nameChangeTextfield: String = ""
+  @Published var showDatePicker: Bool = false
+  @Published var merriageDate: Date = .now
   
   func signOut() throws {
     try AuthenticationManager.shared.signOut()
@@ -30,6 +32,11 @@ final class MyAccountViewModel: ObservableObject {
   func updateMyName(name: String) throws {
     let myId: String = try AuthenticationManager.shared.getAuthenticatedUser().uid
     try UserManager.shared.updateUserName(userId: myId, name: name)
+  }
+  
+  func updateMyMarriageDate(date: Date) throws {
+    let myId: String = try AuthenticationManager.shared.getAuthenticatedUser().uid
+    try UserManager.shared.updateMarriageDate(userId: myId, date: date)
   }
   
   private func calculateDDay(estimatedMarriageDate: Date) -> Int {


### PR DESCRIPTION
#### close #69 

### ✏️ 개요
내 계정 뷰에서 할 수 있는 동작들을 구현하였습니다.

### 💻 작업 사항
- 이름 변경 기능 구현
- 결혼 예정일 변경 기능 구현
- 로그아웃 안내 모달 구현

### 📄 리뷰 노트
@JINi0S 의 데이트 피커를 참고하여 결혼 예정일 변경 기능을 구현하였습니다.

### 📱결과 화면(optional)
|정보 변경 액션시트|이름 변경|
|---|---|
|<img width="511" alt="Untitled" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/77708819/aec1d4c4-5651-4f20-84a8-d52cd909f97e">|<img width="511" alt="Untitled" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/77708819/9fde83f9-a807-4c7a-bd22-5308fc9bda5b">|

|캘린더 뷰|변경 동작 실행 후|
|---|---|
|<img width="511" alt="Untitled" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/77708819/1005df82-afe2-49a6-bdd9-315f6808cabb">|<img width="511" alt="Untitled" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/77708819/e26fdf3f-0b4f-45e1-9683-a5382eae5787">|



### 📚 ETC(optional)
Alert의 버튼 UI를 피그마와 똑같이 구현하기에 공수가 많이 들 것 같아, 잠정 보류하였습니다.
1. 버튼이 2개일 때, 세로로 버튼 표시
2. Confirm 버튼의 FontWeight 변경
