### PR TITLE
[Feat/#72] 응답 기능 구현

### DIFF
--- a/ABloom/ABloom.xcodeproj/project.pbxproj
+++ b/ABloom/ABloom.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		3D44127C2AEAC3C000FD5A51 /* ConnectedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D44127B2AEAC3C000FD5A51 /* ConnectedView.swift */; };
 		3D44127E2AEAC57500FD5A51 /* ConnectionWaypointView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D44127D2AEAC57500FD5A51 /* ConnectionWaypointView.swift */; };
 		3D4412802AEACA2A00FD5A51 /* ConnectionWaypointViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D44127F2AEACA2A00FD5A51 /* ConnectionWaypointViewModel.swift */; };
+		3D957E872AEE5C5800D565E9 /* Ex+ Query.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D957E862AEE5C5800D565E9 /* Ex+ Query.swift */; };
 		3DB6A5752AE0BDF800C1369F /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5742AE0BDF800C1369F /* FirebaseAnalytics */; };
 		3DB6A5772AE0BDF800C1369F /* FirebaseAnalyticsOnDeviceConversion in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5762AE0BDF800C1369F /* FirebaseAnalyticsOnDeviceConversion */; };
 		3DB6A5792AE0BDF800C1369F /* FirebaseAnalyticsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5782AE0BDF800C1369F /* FirebaseAnalyticsSwift */; };
@@ -114,6 +115,7 @@
 		3D44127B2AEAC3C000FD5A51 /* ConnectedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedView.swift; sourceTree = "<group>"; };
 		3D44127D2AEAC57500FD5A51 /* ConnectionWaypointView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionWaypointView.swift; sourceTree = "<group>"; };
 		3D44127F2AEACA2A00FD5A51 /* ConnectionWaypointViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionWaypointViewModel.swift; sourceTree = "<group>"; };
+		3D957E862AEE5C5800D565E9 /* Ex+ Query.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ex+ Query.swift"; sourceTree = "<group>"; };
 		3DB6A5AA2AE0C09800C1369F /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		3DB6A5AD2AE0C12B00C1369F /* AppleLoginButtonViewRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginButtonViewRepresentable.swift; sourceTree = "<group>"; };
 		3DB6A5B02AE11C2D00C1369F /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
@@ -474,6 +476,7 @@
 				6053F15E2ADF6C3B0064A6E0 /* Ex+View.swift */,
 				AE8D3C502ADE19E0009899A7 /* Ex+Font.swift */,
 				AE8D3C602ADE3C73009899A7 /* Ex+Shape.swift */,
+				3D957E862AEE5C5800D565E9 /* Ex+ Query.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -655,6 +658,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3D957E872AEE5C5800D565E9 /* Ex+ Query.swift in Sources */,
 				3D4412782AE9F5E600FD5A51 /* ServiceWebURL.swift in Sources */,
 				AE8D3C512ADE19E0009899A7 /* Ex+Font.swift in Sources */,
 				3D4412542AE4EE2C00FD5A51 /* MenuListNavigationItem.swift in Sources */,

--- a/ABloom/ABloom.xcodeproj/project.pbxproj
+++ b/ABloom/ABloom.xcodeproj/project.pbxproj
@@ -27,6 +27,10 @@
 		3D44127E2AEAC57500FD5A51 /* ConnectionWaypointView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D44127D2AEAC57500FD5A51 /* ConnectionWaypointView.swift */; };
 		3D4412802AEACA2A00FD5A51 /* ConnectionWaypointViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D44127F2AEACA2A00FD5A51 /* ConnectionWaypointViewModel.swift */; };
 		3D957E872AEE5C5800D565E9 /* Ex+ Query.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D957E862AEE5C5800D565E9 /* Ex+ Query.swift */; };
+		3D957E892AEE7ECF00D565E9 /* AnswerCheckViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D957E882AEE7ECF00D565E9 /* AnswerCheckViewModel.swift */; };
+		3D957E8C2AEE7F1000D565E9 /* DBUserModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D957E8B2AEE7F1000D565E9 /* DBUserModel.swift */; };
+		3D957E8E2AEE7F2E00D565E9 /* DBStaticQuestionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D957E8D2AEE7F2E00D565E9 /* DBStaticQuestionModel.swift */; };
+		3D957E902AEE7F4800D565E9 /* DBAnswerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D957E8F2AEE7F4800D565E9 /* DBAnswerModel.swift */; };
 		3DB6A5752AE0BDF800C1369F /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5742AE0BDF800C1369F /* FirebaseAnalytics */; };
 		3DB6A5772AE0BDF800C1369F /* FirebaseAnalyticsOnDeviceConversion in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5762AE0BDF800C1369F /* FirebaseAnalyticsOnDeviceConversion */; };
 		3DB6A5792AE0BDF800C1369F /* FirebaseAnalyticsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5782AE0BDF800C1369F /* FirebaseAnalyticsSwift */; };
@@ -116,6 +120,10 @@
 		3D44127D2AEAC57500FD5A51 /* ConnectionWaypointView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionWaypointView.swift; sourceTree = "<group>"; };
 		3D44127F2AEACA2A00FD5A51 /* ConnectionWaypointViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionWaypointViewModel.swift; sourceTree = "<group>"; };
 		3D957E862AEE5C5800D565E9 /* Ex+ Query.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ex+ Query.swift"; sourceTree = "<group>"; };
+		3D957E882AEE7ECF00D565E9 /* AnswerCheckViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerCheckViewModel.swift; sourceTree = "<group>"; };
+		3D957E8B2AEE7F1000D565E9 /* DBUserModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBUserModel.swift; sourceTree = "<group>"; };
+		3D957E8D2AEE7F2E00D565E9 /* DBStaticQuestionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBStaticQuestionModel.swift; sourceTree = "<group>"; };
+		3D957E8F2AEE7F4800D565E9 /* DBAnswerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBAnswerModel.swift; sourceTree = "<group>"; };
 		3DB6A5AA2AE0C09800C1369F /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		3DB6A5AD2AE0C12B00C1369F /* AppleLoginButtonViewRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginButtonViewRepresentable.swift; sourceTree = "<group>"; };
 		3DB6A5B02AE11C2D00C1369F /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
@@ -278,11 +286,22 @@
 			path = Utilities;
 			sourceTree = "<group>";
 		};
+		3D957E8A2AEE7EF300D565E9 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				3D957E8B2AEE7F1000D565E9 /* DBUserModel.swift */,
+				3D957E8D2AEE7F2E00D565E9 /* DBStaticQuestionModel.swift */,
+				3D957E8F2AEE7F4800D565E9 /* DBAnswerModel.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
 		3DB6A5AC2AE0C0B700C1369F /* Firebase */ = {
 			isa = PBXGroup;
 			children = (
 				3D4412412AE388CC00FD5A51 /* Firestore */,
 				3DB6A5B22AE11CBA00C1369F /* Authentication */,
+				3D957E8A2AEE7EF300D565E9 /* Model */,
 			);
 			path = Firebase;
 			sourceTree = "<group>";
@@ -381,6 +400,7 @@
 				AE5693242AEAD982009F3400 /* AnswerWriteViewModel.swift */,
 				AE1AEA002AE55A0C0010089F /* QuestionMainViewModel.swift */,
 				AEEA8DCE2AEB82070068550E /* SelectQuestionViewModel.swift */,
+				3D957E882AEE7ECF00D565E9 /* AnswerCheckViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -658,6 +678,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3D957E8C2AEE7F1000D565E9 /* DBUserModel.swift in Sources */,
 				3D957E872AEE5C5800D565E9 /* Ex+ Query.swift in Sources */,
 				3D4412782AE9F5E600FD5A51 /* ServiceWebURL.swift in Sources */,
 				AE8D3C512ADE19E0009899A7 /* Ex+Font.swift in Sources */,
@@ -682,6 +703,8 @@
 				AEB502642AE5FA840056E439 /* CustomNavigationBarModifier.swift in Sources */,
 				6053F15B2ADEB7700064A6E0 /* RegistrationViewModel.swift in Sources */,
 				3D4412582AE4F71000FD5A51 /* PolicyView.swift in Sources */,
+				3D957E902AEE7F4800D565E9 /* DBAnswerModel.swift in Sources */,
+				3D957E892AEE7ECF00D565E9 /* AnswerCheckViewModel.swift in Sources */,
 				6053F1712AE17A260064A6E0 /* HomeRecommendView.swift in Sources */,
 				6055411A2ADE66B000AD5625 /* RegistrationView.swift in Sources */,
 				AEAB19372ADF77210057BC43 /* Buttons.swift in Sources */,
@@ -713,6 +736,7 @@
 				AE5693252AEAD982009F3400 /* AnswerWriteViewModel.swift in Sources */,
 				AE1AE9F92AE50BBC0010089F /* QuestionMainView.swift in Sources */,
 				6053F1782AE954760064A6E0 /* ConnectionViewModel.swift in Sources */,
+				3D957E8E2AEE7F2E00D565E9 /* DBStaticQuestionModel.swift in Sources */,
 				AE1AEA012AE55A0C0010089F /* QuestionMainViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ABloom/ABloom/Firebase/Firestore/StaticQuestionManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/StaticQuestionManager.swift
@@ -44,9 +44,25 @@ final class StaticQuestionManager {
   static let shared = StaticQuestionManager()
   
   private let questionCollection = Firestore.firestore().collection("questions")
-
+  
   // MARK: GET Method
-  func getAllQuestions() async throws -> [DBStaticQuestion] {
-    try await questionCollection.getDocuments(as: DBStaticQuestion.self)
+  func getAllQuestions(userId: String) async throws -> [DBStaticQuestion] {
+    // 내가 이미 작성한 문항은 제외하고 GET
+    let ids = try await getMyAnswersId(userId: userId)
+    return try await  questionCollection
+      .whereField(DBStaticQuestion.CodingKeys.questionID.rawValue, notIn: ids)
+      .getDocuments(as: DBStaticQuestion.self)
+  }
+  
+  func getMyAnswersId(userId: String) async throws -> [Int] {
+    let myAnswers = try await UserManager.shared.getMyAnswers(userId: userId)
+    
+    return myAnswers.map { answer in answer.questionId }
+  }
+  
+  func getAnswerdQuestions(questionIds: [Int]) async throws -> [DBStaticQuestion] {
+    return try await questionCollection
+      .whereField(DBStaticQuestion.CodingKeys.questionID.rawValue, in: questionIds)
+      .getDocuments(as: DBStaticQuestion.self)
   }
 }

--- a/ABloom/ABloom/Firebase/Firestore/StaticQuestionManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/StaticQuestionManager.swift
@@ -7,39 +7,6 @@ import FirebaseFirestore
 import FirebaseFirestoreSwift
 import Foundation
 
-/// DB에 저장된 Static Quesiton
-struct DBStaticQuestion: Codable, Hashable {
-  let questionID: Int
-  let category: String
-  let content: String
-  
-  init(questionID: Int, category: String, content: String) {
-    self.questionID = questionID
-    self.category = category
-    self.content = content
-  }
-  
-  enum CodingKeys: String, CodingKey {
-    case questionID = "q_id"
-    case category = "category"
-    case content = "content"
-  }
-  
-  func encode(to encoder: Encoder) throws {
-    var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encode(self.questionID, forKey: .questionID)
-    try container.encode(self.category, forKey: .category)
-    try container.encode(self.content, forKey: .content)
-  }
-  
-  init(from decoder: Decoder) throws {
-    let container = try decoder.container(keyedBy: CodingKeys.self)
-    self.questionID = try container.decode(Int.self, forKey: .questionID)
-    self.category = try container.decode(String.self, forKey: .category)
-    self.content = try container.decode(String.self, forKey: .content)
-  }
-}
-
 final class StaticQuestionManager {
   static let shared = StaticQuestionManager()
   

--- a/ABloom/ABloom/Firebase/Firestore/StaticQuestionManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/StaticQuestionManager.swift
@@ -61,8 +61,12 @@ final class StaticQuestionManager {
   }
   
   func getAnswerdQuestions(questionIds: [Int]) async throws -> [DBStaticQuestion] {
-    return try await questionCollection
+    try await questionCollection
       .whereField(DBStaticQuestion.CodingKeys.questionID.rawValue, in: questionIds)
       .getDocuments(as: DBStaticQuestion.self)
+  }
+  
+  func getQuestionById(id: Int) async throws -> DBStaticQuestion {
+    try await questionCollection.document("\(id)").getDocument(as: DBStaticQuestion.self)
   }
 }

--- a/ABloom/ABloom/Firebase/Firestore/StaticQuestionManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/StaticQuestionManager.swift
@@ -47,14 +47,6 @@ final class StaticQuestionManager {
 
   // MARK: GET Method
   func getAllQuestions() async throws -> [DBStaticQuestion] {
-    let snapshot = try await questionCollection.getDocuments()
-    
-    var questions: [DBStaticQuestion] = []
-    
-    for document in snapshot.documents {
-      let question = try document.data(as: DBStaticQuestion.self)
-      questions.append(question)
-    }
-    return questions
+    try await questionCollection.getDocuments(as: DBStaticQuestion.self)
   }
 }

--- a/ABloom/ABloom/Firebase/Firestore/UserManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/UserManager.swift
@@ -133,6 +133,11 @@ final class UserManager {
     
     try? document.setData(from: data, merge: false)
   }
+  
+  func getMyAnswers(userId: String) async throws -> [AnswerModel] {
+    let collection = userAnswerCollection(userId: userId)
+    return try await collection.getDocuments(as: AnswerModel.self)
+  }
 }
 
 

--- a/ABloom/ABloom/Firebase/Firestore/UserManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/UserManager.swift
@@ -9,63 +9,6 @@ import FirebaseFirestore
 import FirebaseFirestoreSwift
 import Foundation
 
-/// DB에 저장될 User Model
-struct DBUser: Codable {
-  let userId: String
-  let name: String?
-  let sex: Bool?
-  let estimatedMarriageDate: Date?
-  let invitationCode: String?
-  let fiance: String?
-  
-  init(userId: String, name: String, sex: Bool, estimatedMarriageDate: Date, invitationCode: String, fiance: String? = nil) {
-    self.userId = userId
-    self.name = name
-    self.sex = sex
-    self.estimatedMarriageDate = estimatedMarriageDate
-    self.invitationCode = invitationCode
-    self.fiance = fiance
-  }
-  
-  init(auth: AuthDataResultModel) {
-    self.userId = auth.uid
-    self.name = auth.name
-    self.sex = nil
-    self.estimatedMarriageDate = nil
-    self.invitationCode = nil
-    self.fiance = nil
-  }
-  
-  enum CodingKeys: String, CodingKey {
-    case userId = "user_id"
-    case name = "name"
-    case sex = "sex"
-    case estimatedMarriageDate = "estimated_marriage_date"
-    case invitationCode = "invitation_code"
-    case fiance = "fiance"
-  }
-  
-  func encode(to encoder: Encoder) throws {
-    var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encode(self.userId, forKey: .userId)
-    try container.encode(self.name, forKey: .name)
-    try container.encode(self.sex, forKey: .sex)
-    try container.encode(self.estimatedMarriageDate, forKey: .estimatedMarriageDate)
-    try container.encode(self.invitationCode, forKey: .invitationCode)
-    try container.encode(self.fiance, forKey: .fiance)
-  }
-  
-  init(from decoder: Decoder) throws {
-    let container = try decoder.container(keyedBy: CodingKeys.self)
-    self.userId = try container.decode(String.self, forKey: .userId)
-    self.name = try container.decode(String.self, forKey: .name)
-    self.sex = try container.decode(Bool.self, forKey: .sex)
-    self.estimatedMarriageDate = try container.decode(Date.self, forKey: .estimatedMarriageDate)
-    self.invitationCode = try container.decode(String.self, forKey: .invitationCode)
-    self.fiance = try container.decodeIfPresent(String.self, forKey: .fiance)
-  }
-}
-
 final class UserManager {
   static let shared = UserManager()
   
@@ -129,46 +72,13 @@ final class UserManager {
     let collection = userAnswerCollection(userId: userId)
     let document = collection.document()
     
-    let data = AnswerModel(questionId: questionId, answerContent: content)
+    let data = DBAnswer(questionId: questionId, answerContent: content)
     
     try? document.setData(from: data, merge: false)
   }
   
-  func getMyAnswers(userId: String) async throws -> [AnswerModel] {
+  func getMyAnswers(userId: String) async throws -> [DBAnswer] {
     let collection = userAnswerCollection(userId: userId)
-    return try await collection.getDocuments(as: AnswerModel.self)
-  }
-}
-
-
-struct AnswerModel: Codable {
-  let questionId: Int
-  let date: Date
-  let answerContent: String
-  
-  init(questionId: Int, date: Date = .now, answerContent: String) {
-    self.questionId = questionId
-    self.date = date
-    self.answerContent = answerContent
-  }
-  
-  enum CodingKeys: String, CodingKey {
-    case questionId = "q_id"
-    case date = "date"
-    case answerContent = "answer_content"
-  }
-  
-  init(from decoder: Decoder) throws {
-    let container = try decoder.container(keyedBy: CodingKeys.self)
-    self.questionId = try container.decode(Int.self, forKey: .questionId)
-    self.date = try container.decode(Date.self, forKey: .date)
-    self.answerContent = try container.decode(String.self, forKey: .answerContent)
-  }
-  
-  func encode(to encoder: Encoder) throws {
-    var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encode(self.questionId, forKey: .questionId)
-    try container.encode(self.date, forKey: .date)
-    try container.encode(self.answerContent, forKey: .answerContent)
+    return try await collection.getDocuments(as: DBAnswer.self)
   }
 }

--- a/ABloom/ABloom/Firebase/Model/DBAnswerModel.swift
+++ b/ABloom/ABloom/Firebase/Model/DBAnswerModel.swift
@@ -1,0 +1,40 @@
+//
+//  DBAnswerModel.swift
+//  ABloom
+//
+//  Created by 정승균 on 10/29/23.
+//
+
+import Foundation
+
+struct DBAnswer: Codable {
+  let questionId: Int
+  let date: Date
+  let answerContent: String
+  
+  init(questionId: Int, date: Date = .now, answerContent: String) {
+    self.questionId = questionId
+    self.date = date
+    self.answerContent = answerContent
+  }
+  
+  enum CodingKeys: String, CodingKey {
+    case questionId = "q_id"
+    case date = "date"
+    case answerContent = "answer_content"
+  }
+  
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.questionId = try container.decode(Int.self, forKey: .questionId)
+    self.date = try container.decode(Date.self, forKey: .date)
+    self.answerContent = try container.decode(String.self, forKey: .answerContent)
+  }
+  
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(self.questionId, forKey: .questionId)
+    try container.encode(self.date, forKey: .date)
+    try container.encode(self.answerContent, forKey: .answerContent)
+  }
+}

--- a/ABloom/ABloom/Firebase/Model/DBStaticQuestionModel.swift
+++ b/ABloom/ABloom/Firebase/Model/DBStaticQuestionModel.swift
@@ -1,0 +1,41 @@
+//
+//  DBStaticQuestionModel.swift
+//  ABloom
+//
+//  Created by 정승균 on 10/29/23.
+//
+
+import Foundation
+
+/// DB에 저장된 Static Quesiton
+struct DBStaticQuestion: Codable, Hashable {
+  let questionID: Int
+  let category: String
+  let content: String
+  
+  init(questionID: Int, category: String, content: String) {
+    self.questionID = questionID
+    self.category = category
+    self.content = content
+  }
+  
+  enum CodingKeys: String, CodingKey {
+    case questionID = "q_id"
+    case category = "category"
+    case content = "content"
+  }
+  
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(self.questionID, forKey: .questionID)
+    try container.encode(self.category, forKey: .category)
+    try container.encode(self.content, forKey: .content)
+  }
+  
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.questionID = try container.decode(Int.self, forKey: .questionID)
+    self.category = try container.decode(String.self, forKey: .category)
+    self.content = try container.decode(String.self, forKey: .content)
+  }
+}

--- a/ABloom/ABloom/Firebase/Model/DBUserModel.swift
+++ b/ABloom/ABloom/Firebase/Model/DBUserModel.swift
@@ -1,0 +1,64 @@
+//
+//  DBUserModel.swift
+//  ABloom
+//
+//  Created by 정승균 on 10/29/23.
+//
+
+import Foundation
+/// DB에 저장될 User Model
+struct DBUser: Codable {
+  let userId: String
+  let name: String?
+  let sex: Bool?
+  let estimatedMarriageDate: Date?
+  let invitationCode: String?
+  let fiance: String?
+  
+  init(userId: String, name: String, sex: Bool, estimatedMarriageDate: Date, invitationCode: String, fiance: String? = nil) {
+    self.userId = userId
+    self.name = name
+    self.sex = sex
+    self.estimatedMarriageDate = estimatedMarriageDate
+    self.invitationCode = invitationCode
+    self.fiance = fiance
+  }
+  
+  init(auth: AuthDataResultModel) {
+    self.userId = auth.uid
+    self.name = auth.name
+    self.sex = nil
+    self.estimatedMarriageDate = nil
+    self.invitationCode = nil
+    self.fiance = nil
+  }
+  
+  enum CodingKeys: String, CodingKey {
+    case userId = "user_id"
+    case name = "name"
+    case sex = "sex"
+    case estimatedMarriageDate = "estimated_marriage_date"
+    case invitationCode = "invitation_code"
+    case fiance = "fiance"
+  }
+  
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(self.userId, forKey: .userId)
+    try container.encode(self.name, forKey: .name)
+    try container.encode(self.sex, forKey: .sex)
+    try container.encode(self.estimatedMarriageDate, forKey: .estimatedMarriageDate)
+    try container.encode(self.invitationCode, forKey: .invitationCode)
+    try container.encode(self.fiance, forKey: .fiance)
+  }
+  
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.userId = try container.decode(String.self, forKey: .userId)
+    self.name = try container.decode(String.self, forKey: .name)
+    self.sex = try container.decode(Bool.self, forKey: .sex)
+    self.estimatedMarriageDate = try container.decode(Date.self, forKey: .estimatedMarriageDate)
+    self.invitationCode = try container.decode(String.self, forKey: .invitationCode)
+    self.fiance = try container.decodeIfPresent(String.self, forKey: .fiance)
+  }
+}

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerCheckView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerCheckView.swift
@@ -7,21 +7,56 @@
 
 import SwiftUI
 
+@MainActor
+final class AnswerCheckViewModel: ObservableObject {
+  @Published var question: DBStaticQuestion? = nil
+  @Published var fianceAnswer: String = ""
+  @Published var myAnswer: String = ""
+  let questionId: Int
+  
+  init(fianceAnswer: String = "", myAnswer: String = "", questionId: Int) {
+    self.fianceAnswer = fianceAnswer
+    self.myAnswer = myAnswer
+    self.questionId = questionId
+  }
+  
+  func getAnswers() {
+    // TODO: 나의 응답, 상대방 응답
+    Task {
+      try? await getQuestion(by: self.questionId)
+      getMyAnswer()
+      getFianceAnswer()
+    }
+  }
+  
+  private func getMyAnswer() {
+    // TODO: 내 응답 불러오기
+  }
+  
+  private func getFianceAnswer() {
+    // TODO: 상대방 응답 불러오기
+  }
+  
+  private func getQuestion(by id: Int) async throws {
+    // TODO: 질문 불러오기
+    self.question = try await StaticQuestionManager.shared.getQuestionById(id: id)
+  }
+}
+
 struct AnswerCheckView: View {
   @Environment(\.dismiss) private var dismiss
-  
-  // 차후에 데이터를 받아올 변수 => 현재는 임의로 지정
-  let num: Int
+  @StateObject var answerCheckVM: AnswerCheckViewModel
   
   var body: some View {
     VStack {
-      
-      CategoryQuestionBox(
-        question: "반려동물을 기르고 싶어?",
-        category: "경제 질문",
-        categoryImg: "squareIcon_isometric_health"
-      )
-      .padding(.vertical, 30)
+      if let question = answerCheckVM.question {
+        CategoryQuestionBox(
+          question: question.content,
+          category: "\((Category(rawValue: question.category)?.type)!) 질문",
+          categoryImg: (Category(rawValue: question.category)?.imgName)!
+        )
+        .padding(.vertical, 30)
+      }
       
       Spacer()
         .frame(height: 10)
@@ -48,6 +83,9 @@ struct AnswerCheckView: View {
       .padding(.horizontal, 20)
       .background(backWall())
     }
+    .onAppear {
+      answerCheckVM.getAnswers()
+    }
     
     .customNavigationBar(
       centerView: {
@@ -71,5 +109,5 @@ struct AnswerCheckView: View {
 }
 
 #Preview {
-  AnswerCheckView(num: 1)
+  AnswerCheckView(answerCheckVM: .init(questionId: 1))
 }

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerCheckView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerCheckView.swift
@@ -7,42 +7,6 @@
 
 import SwiftUI
 
-@MainActor
-final class AnswerCheckViewModel: ObservableObject {
-  @Published var question: DBStaticQuestion? = nil
-  @Published var fianceAnswer: String = ""
-  @Published var myAnswer: String = ""
-  let questionId: Int
-  
-  init(fianceAnswer: String = "", myAnswer: String = "", questionId: Int) {
-    self.fianceAnswer = fianceAnswer
-    self.myAnswer = myAnswer
-    self.questionId = questionId
-  }
-  
-  func getAnswers() {
-    // TODO: 나의 응답, 상대방 응답
-    Task {
-      try? await getQuestion(by: self.questionId)
-      getMyAnswer()
-      getFianceAnswer()
-    }
-  }
-  
-  private func getMyAnswer() {
-    // TODO: 내 응답 불러오기
-  }
-  
-  private func getFianceAnswer() {
-    // TODO: 상대방 응답 불러오기
-  }
-  
-  private func getQuestion(by id: Int) async throws {
-    // TODO: 질문 불러오기
-    self.question = try await StaticQuestionManager.shared.getQuestionById(id: id)
-  }
-}
-
 struct AnswerCheckView: View {
   @Environment(\.dismiss) private var dismiss
   @StateObject var answerCheckVM: AnswerCheckViewModel

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerWriteView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerWriteView.swift
@@ -41,9 +41,9 @@ struct AnswerWriteView: View {
         })
       },
       rightView: {
-        NavigationLink {
-          // popToRoot 구현 => NavigationStack path 설정 필요
-          // QuestionMainView()
+        Button {
+          try? answerVM.createAnswer(questionId: question.questionID)
+          dismiss()
         } label: {
           Text("완료")
             .fontWithTracking(.headlineR)
@@ -70,4 +70,8 @@ extension AnswerWriteView {
     }
     .padding(.horizontal, 22)
   }
+}
+
+#Preview {
+  AnswerWriteView(question: .init(questionID: 1, category: "values", content: "반려동물을 기르고싶어?"))
 }

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/QuestionMainView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/QuestionMainView.swift
@@ -27,7 +27,7 @@ struct QuestionMainView: View {
             if content == 0 {
               SelectQuestionView()
             } else {
-              AnswerCheckView(num: content)
+              AnswerCheckView(answerCheckVM: .init(questionId: content))
             }
           })
           .background(backWall())

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/QuestionMainView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/QuestionMainView.swift
@@ -10,31 +10,33 @@ import SwiftUI
 struct QuestionMainView: View {
   @StateObject var questionVM = QuestionMainViewModel()
   
-  
   var body: some View {
-    
     VStack {
       headerView
       
       Spacer()
         .frame(height: 34)
       
-      // if empty
-      emptyListView
-      
-      // else
-      // answeredQScroll
-      
-        .navigationDestination(for: Int.self, destination: { content in
-          if content == 0 {
-            SelectQuestionView()
-          } else {
-            AnswerCheckView(num: content)
-          }
-        })
-        .background(backWall())
+      if questionVM.myAnwsers.isEmpty {
+        emptyListView
+          .background(backWall())
+          
+      } else {
+        answeredQScroll
+          .navigationDestination(for: Int.self, destination: { content in
+            if content == 0 {
+              SelectQuestionView()
+            } else {
+              AnswerCheckView(num: content)
+            }
+          })
+          .background(backWall())
+      }
     }
     .background(backgroundDefault())
+    .task {
+      try? await questionVM.getMyAnswers()
+    }
   }
 }
 
@@ -64,10 +66,14 @@ extension QuestionMainView {
         Spacer()
           .frame(height: 0)
         
-        ForEach(1..<3) { num in
-          NavigationLink(value: num) {
+        ForEach(questionVM.questions, id: \.questionID) { question in
+          NavigationLink(value: question.questionID) {
             // TODO: 해당 정보란을 데이터로 가져와야함
-            QnAListItem(categoryImg: "squareIcon_isometric_sofa", question: "나와 결혼을 결심한 순간은 언제야?\(num)", date: "2023년 9월 18일", isAns: false)
+            QnAListItem(
+              categoryImg: (Category(rawValue: question.category)?.imgName)!,
+              question: question.content,
+              date: (questionVM.myAnwsers.first(where: { $0.questionId == question.questionID })?.date)!,
+              isAns: false)
           }
         }
       }

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/AnswerCheckViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/AnswerCheckViewModel.swift
@@ -1,0 +1,44 @@
+//
+//  AnswerCheckViewModel.swift
+//  ABloom
+//
+//  Created by 정승균 on 10/29/23.
+//
+
+import Foundation
+
+@MainActor
+final class AnswerCheckViewModel: ObservableObject {
+  @Published var question: DBStaticQuestion? = nil
+  @Published var fianceAnswer: String = ""
+  @Published var myAnswer: String = ""
+  let questionId: Int
+  
+  init(fianceAnswer: String = "", myAnswer: String = "", questionId: Int) {
+    self.fianceAnswer = fianceAnswer
+    self.myAnswer = myAnswer
+    self.questionId = questionId
+  }
+  
+  func getAnswers() {
+    // TODO: 나의 응답, 상대방 응답
+    Task {
+      try? await getQuestion(by: self.questionId)
+      getMyAnswer()
+      getFianceAnswer()
+    }
+  }
+  
+  private func getMyAnswer() {
+    // TODO: 내 응답 불러오기
+  }
+  
+  private func getFianceAnswer() {
+    // TODO: 상대방 응답 불러오기
+  }
+  
+  private func getQuestion(by id: Int) async throws {
+    // TODO: 질문 불러오기
+    self.question = try await StaticQuestionManager.shared.getQuestionById(id: id)
+  }
+}

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/AnswerWriteViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/AnswerWriteViewModel.swift
@@ -10,8 +10,8 @@ import SwiftUI
 class AnswerWriteViewModel: ObservableObject {
   @Published var answerText: String = ""
   
-  // 문답 저장
-  func saveAns() {
-    
+  func createAnswer(questionId: Int) throws {
+    let user = try AuthenticationManager.shared.getAuthenticatedUser()
+    try UserManager.shared.creatAnswer(userId: user.uid, questionId: questionId, content: answerText)
   }
 }

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/QuestionMainViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/QuestionMainViewModel.swift
@@ -51,7 +51,7 @@ enum Category: String, CaseIterable {
 }
 @MainActor
 final class QuestionMainViewModel: ObservableObject {
-  @Published var myAnwsers: [AnswerModel] = []
+  @Published var myAnwsers: [DBAnswer] = []
   @Published var questions: [DBStaticQuestion] = []
   
   func getMyAnswers() async throws {

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/QuestionMainViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/QuestionMainViewModel.swift
@@ -49,7 +49,18 @@ enum Category: String, CaseIterable {
     }
   }
 }
-
-class QuestionMainViewModel: ObservableObject {
-
+@MainActor
+final class QuestionMainViewModel: ObservableObject {
+  @Published var myAnwsers: [AnswerModel] = []
+  @Published var questions: [DBStaticQuestion] = []
+  
+  func getMyAnswers() async throws {
+    let userId = try AuthenticationManager.shared.getAuthenticatedUser().uid
+    
+    let myAnswers = try await UserManager.shared.getMyAnswers(userId: userId)
+    let questions = try await StaticQuestionManager.shared.getAnswerdQuestions(questionIds: myAnswers.map({ $0.questionId }))
+    
+    self.myAnwsers = myAnswers
+    self.questions = questions
+  }
 }

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/SelectQuestionViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/SelectQuestionViewModel.swift
@@ -29,7 +29,8 @@ final class SelectQuestionViewModel: ObservableObject {
   }
   
   func fetchQuestions() async throws {
-    self.questionLists = try await StaticQuestionManager.shared.getAllQuestions()
+    let userId = try AuthenticationManager.shared.getAuthenticatedUser().uid
+    self.questionLists = try await StaticQuestionManager.shared.getAllQuestions(userId: userId)
     filterQuestion()
   }
 }

--- a/ABloom/ABloom/Resources/Components/QnAListItem.swift
+++ b/ABloom/ABloom/Resources/Components/QnAListItem.swift
@@ -10,8 +10,14 @@ import SwiftUI
 struct QnAListItem: View {
   let categoryImg: String
   let question: String
-  let date: String
+  let date: Date
   let isAns: Bool
+  
+  var formattedWeddingDate: String {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy년 MM월 dd일"
+    return formatter.string(from: date)
+  }
   
   var body: some View {
     HStack(spacing: 15) {
@@ -31,11 +37,12 @@ struct QnAListItem: View {
           Text(question)
             .fontWithTracking(.caption1Bold)
             .foregroundStyle(.black)
+            .lineLimit(1)
           
           Spacer()
         }
         HStack {
-          Text(date)
+          Text(formattedWeddingDate)
             .fontWithTracking(.caption2R)
           
           Spacer()
@@ -52,5 +59,5 @@ struct QnAListItem: View {
 }
 
 #Preview {
-  QnAListItem(categoryImg: "squareIcon_isometric_health", question: "나와 결혼을 결심한 순간은 언제야?", date: "2023년 9월 18일", isAns: false)
+  QnAListItem(categoryImg: "squareIcon_isometric_health", question: "나와 결혼을 결심한 순간은 언제야?", date: .now, isAns: false)
 }

--- a/ABloom/ABloom/Resources/Extensions/Ex+ Query.swift
+++ b/ABloom/ABloom/Resources/Extensions/Ex+ Query.swift
@@ -1,0 +1,22 @@
+//
+//  Ex+ Query.swift
+//  ABloom
+//
+//  Created by 정승균 on 10/29/23.
+//
+
+import FirebaseFirestore
+import FirebaseFirestoreSwift
+
+extension Query {
+  /// 한 번에 많은 도큐먼트를 불러올 수 있도록 하는 함수
+  func getDocuments<T>(as type: T.Type) async throws -> [T] where T: Decodable {
+    // query snapshot
+    let snapshot = try await self.getDocuments()
+    
+    // 2. 고급 함수를 이용하여 구현하기
+    return try snapshot.documents.map { document in
+      return try document.data(as: T.self)
+    }
+  }
+}

--- a/ABloom/ABloom/Resources/Extensions/Ex+ Query.swift
+++ b/ABloom/ABloom/Resources/Extensions/Ex+ Query.swift
@@ -14,7 +14,7 @@ extension Query {
     // query snapshot
     let snapshot = try await self.getDocuments()
     
-    // 2. 고급 함수를 이용하여 구현하기
+    // 고급 함수를 이용하여 구현하기
     return try snapshot.documents.map { document in
       return try document.data(as: T.self)
     }


### PR DESCRIPTION
#### close #72 

### ✏️ 개요
질문에 응답하는 기능을 구현했습니다.

### 💻 작업 사항
- 응답 생성하기: 사용자가 질문에 응답하면, 그 값을 Firestore에 저장합니다.
- 답변 시 해당 문항 질문 선택 리스트에서 제거: 질문을 불러올 때, 이미 답변한 질문은 제외하고 가져옵니다.
- 답변된 질문을 '질문 메인 뷰'에 표시
- 답변 확인 뷰에 질문 연동

### 📄 리뷰 노트
@Hayun218: 문답 확인 뷰에 CategoryQuestionBox 레이아웃을 수정해주세요. 결과화면에 첨부하겠습니다!

### 📱결과 화면(optional)
|응답 보기|응답된 질문은 선택화면에서 제외|답변 확인뷰 질문 연동|
|---|---|---|
|<img width="511" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/77708819/f29440bf-a47a-4c14-bdf4-89e0989af35c">|<img width="511" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/77708819/9d3454d1-33e8-4c2a-bebb-b2f93389b33c">|<img width="511" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/77708819/582a562a-a6e3-491a-992f-990ae73a850a">|


### 📚 ETC(optional)
매니저의 역할이 헤비해진 관계로 코드 가독성을 위해, 파이어 스토어에서 사용하는 데이터 모델들은 Model이라는 그룹을 생성하여 따로 관리하겠습니다.
