### PR TITLE
[Feat/#70] 홈화면 이미지 로컬 저장 및 불러오기 구현

### DIFF
--- a/ABloom/ABloom.xcodeproj/project.pbxproj
+++ b/ABloom/ABloom.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		605541152ADE1A9D00AD5625 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605541142ADE1A9D00AD5625 /* TabBarView.swift */; };
 		605541172ADE1ACF00AD5625 /* Tab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605541162ADE1ACF00AD5625 /* Tab.swift */; };
 		6055411A2ADE66B000AD5625 /* RegistrationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605541192ADE66B000AD5625 /* RegistrationView.swift */; };
+		607DA20C2AEE5028005AE11C /* ImageFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607DA20B2AEE5028005AE11C /* ImageFileManager.swift */; };
 		AE1AE9F92AE50BBC0010089F /* QuestionMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1AE9F82AE50BBC0010089F /* QuestionMainView.swift */; };
 		AE1AE9FB2AE51BF00010089F /* QnAListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1AE9FA2AE51BF00010089F /* QnAListItem.swift */; };
 		AE1AE9FF2AE557E00010089F /* AnswerCheckView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1AE9FE2AE557E00010089F /* AnswerCheckView.swift */; };
@@ -130,6 +131,7 @@
 		605541142ADE1A9D00AD5625 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
 		605541162ADE1ACF00AD5625 /* Tab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tab.swift; sourceTree = "<group>"; };
 		605541192ADE66B000AD5625 /* RegistrationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationView.swift; sourceTree = "<group>"; };
+		607DA20B2AEE5028005AE11C /* ImageFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFileManager.swift; sourceTree = "<group>"; };
 		AE1AE9F82AE50BBC0010089F /* QuestionMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionMainView.swift; sourceTree = "<group>"; };
 		AE1AE9FA2AE51BF00010089F /* QnAListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QnAListItem.swift; sourceTree = "<group>"; };
 		AE1AE9FE2AE557E00010089F /* AnswerCheckView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerCheckView.swift; sourceTree = "<group>"; };
@@ -413,6 +415,7 @@
 			children = (
 				6053F16C2AE178E20064A6E0 /* View */,
 				6053F16F2AE179E50064A6E0 /* ViewModel */,
+				607DA20B2AEE5028005AE11C /* ImageFileManager.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -670,6 +673,7 @@
 				AE1AE9FB2AE51BF00010089F /* QnAListItem.swift in Sources */,
 				AE8D3C512ADE19E0009899A7 /* Ex+Font.swift in Sources */,
 				AEB5026B2AE64B8D0056E439 /* CategoryQuestionBox.swift in Sources */,
+				607DA20C2AEE5028005AE11C /* ImageFileManager.swift in Sources */,
 				AEEA8DD12AEB82290068550E /* SelectQuestionView.swift in Sources */,
 				AE8D3C612ADE3C73009899A7 /* Ex+Shape.swift in Sources */,
 				AE6697902AE904F80004B56C /* AnswerWriteView.swift in Sources */,
@@ -849,6 +853,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ABloom/Info.plist;
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "이미지를 화면에 보여주기 위해 사진 라이브러리 사용 권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -882,6 +887,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ABloom/Info.plist;
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "이미지를 화면에 보여주기 위해 사진 라이브러리 사용 권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/ABloom/ABloom/Presentation/CoreViews/Home/ImageFileManager.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Home/ImageFileManager.swift
@@ -7,7 +7,7 @@
 
 import PhotosUI
 
-class ImageFileManager {
+final class ImageFileManager {
   static let shared = ImageFileManager()
   private let cachePathName: String = "Mery_Images"
   
@@ -37,6 +37,7 @@ class ImageFileManager {
     }
   }
   
+  @discardableResult
   func deleteFolder() -> String {
     guard
       let path = FileManager
@@ -57,6 +58,7 @@ class ImageFileManager {
     }
   }
   
+  @discardableResult
   func saveImage(image: UIImage, name: String) -> String {
     guard let data = image.pngData(), let path = getPathForImage(name: name) else {
       return "ERROR GETTING PATH"
@@ -82,6 +84,7 @@ class ImageFileManager {
     return UIImage(contentsOfFile: path)
   }
   
+  @discardableResult
   func deleteImage(name: String) -> String {
     guard
       let path = getPathForImage(name: name),

--- a/ABloom/ABloom/Presentation/CoreViews/Home/ImageFileManager.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Home/ImageFileManager.swift
@@ -1,0 +1,112 @@
+//
+//  ImageFileManager.swift
+//  ABloom
+//
+//  Created by Lee Jinhee on 10/29/23.
+//
+
+import PhotosUI
+
+class ImageFileManager {
+  static let shared = ImageFileManager()
+  private let cachePathName: String = "Mery_Images"
+  
+  private init() {
+    createFolderIfNeeded()
+  }
+  
+  func createFolderIfNeeded() {
+    guard
+      let path = FileManager
+        .default
+        .urls(for: .cachesDirectory, in: .userDomainMask)
+        .first?
+        .appendingPathComponent(cachePathName)
+        .path else {
+      return
+    }
+    
+    if !FileManager.default.fileExists(atPath: path) {
+      do {
+        try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true, attributes: nil)
+        print("SUCCESS CREATING FOLDER")
+      } catch {
+        print("ERROR CREATING DIRECTORY")
+        print(error.localizedDescription)
+      }
+    }
+  }
+  
+  func deleteFolder() -> String {
+    guard
+      let path = FileManager
+        .default
+        .urls(for: .cachesDirectory, in: .userDomainMask)
+        .first?
+        .appendingPathComponent(cachePathName)
+        .path else {
+      return "ERROR GETTING PATH"
+    }
+    
+    do {
+      try FileManager.default.removeItem(atPath: path)
+      return "SUCCESS DELETING FOLDER"
+    } catch {
+      print(error.localizedDescription)
+      return "ERROR DELETING FOLDER"
+    }
+  }
+  
+  func saveImage(image: UIImage, name: String) -> String {
+    guard let data = image.pngData(), let path = getPathForImage(name: name) else {
+      return "ERROR GETTING PATH"
+    }
+    
+    do {
+      try data.write(to: path)
+      return "SUCCESS SAVING"
+    } catch {
+      print(error.localizedDescription)
+      return "ERROR SAVING IMAGE"
+    }
+  }
+  
+  func loadImage(name: String) -> UIImage? {
+    guard
+      let path = getPathForImage(name: name)?.path,
+      FileManager.default.fileExists(atPath: path) else {
+      print("ERROR GETTTING PATH")
+      return nil
+    }
+    
+    return UIImage(contentsOfFile: path)
+  }
+  
+  func deleteImage(name: String) -> String {
+    guard
+      let path = getPathForImage(name: name),
+      FileManager.default.fileExists(atPath: path.path) else {
+      return "ERROR GETTING PATH"
+    }
+    
+    do {
+      try FileManager.default.removeItem(at: path)
+    } catch {
+      print(error.localizedDescription)
+      return "ERROR DELETING IMAGE"
+    }
+    return "SUCCESS DELETING IMAGE"
+  }
+  
+  func getPathForImage(name: String) -> URL? {
+    guard
+      let path = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)
+        .first?
+        .appendingPathComponent(cachePathName)
+        .appendingPathComponent("\(name).png")
+    else {
+      return nil
+    }
+    return path
+  }
+}

--- a/ABloom/ABloom/Presentation/CoreViews/Home/View/HomeView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Home/View/HomeView.swift
@@ -140,6 +140,10 @@ extension HomeView {
       Button("사진 삭제하기", role: .destructive) {
         homeVM.deleteImage()
       }
+      
+      Button("취소", role: .cancel) {
+        homeVM.showDialog = false
+      }
     }
     
     .photosPicker(isPresented: $homeVM.showPhotosPicker, selection: $homeVM.selectedItem, matching: .all(of: [.images]), photoLibrary: .shared())

--- a/ABloom/ABloom/Presentation/CoreViews/Home/View/HomeView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Home/View/HomeView.swift
@@ -5,6 +5,7 @@
 //  Created by Lee Jinhee on 10/19/23.
 //
 
+import PhotosUI
 import SwiftUI
 
 struct HomeView: View {
@@ -18,7 +19,11 @@ struct HomeView: View {
       
       Spacer().frame(maxHeight: 32)
       
-      mainImageArea
+      if homeVM.savedImage == nil {
+        defaultImage
+      } else {
+        savedImage
+      }
       
       Spacer().frame(maxHeight: 40)
       
@@ -28,7 +33,6 @@ struct HomeView: View {
     }
     .padding(.horizontal, 20)
     .background(backgroundDefault())
-    //.ignoresSafeArea()
     .task {
       try? await homeVM.setInfo()
     }
@@ -86,11 +90,28 @@ extension HomeView {
     }
   }
   
-  private var mainImageArea: some View {
-    Image("HomeDefaultImage")
+  private var savedImage: some View {
+    Image(uiImage: homeVM.savedImage!)
       .resizable()
-      .frame(height: 387)
       .scaledToFill()
+      .frame(maxHeight: 387)
+      .overlay {
+        Color.biPink.opacity(0.2)
+      }
+      .clipShape(RoundedRectangle(cornerRadius: 28))
+      .shadow(color: Color.purple200, radius: 20, x: 0, y: 20)
+      .overlay(alignment: .topTrailing) {
+        ZStack(alignment: .topTrailing) {
+          cameraButton
+        }
+      }
+  }
+  
+  private var defaultImage: some View {
+    Image(uiImage: homeVM.defaultImage)
+      .resizable()
+      .scaledToFit()
+      .frame(maxHeight: 387)
       .clipShape(RoundedRectangle(cornerRadius: 28))
       .shadow(color: Color.purple200, radius: 20, x: 0, y: 20)
       .overlay(alignment: .topTrailing) {
@@ -103,13 +124,35 @@ extension HomeView {
   
   private var cameraButton: some View {
     Button {
-      // TODO: 사진 적용 기능 구현
+      homeVM.cameraButtonTapped()
     } label: {
       Image("camera.filled.circle_outline")
         .resizable()
         .frame(width: 26, height: 26)
+        .padding(.all, 14)
     }
-    .padding(.all, 14)
+    
+    .confirmationDialog("사진", isPresented: $homeVM.showDialog) {
+      Button("사진 추가하기", role: .none) {
+        homeVM.addImageDialogTapped()
+      }
+      
+      Button("사진 삭제하기", role: .destructive) {
+        homeVM.deleteImage()
+      }
+    }
+    
+    .photosPicker(isPresented: $homeVM.showPhotosPicker, selection: $homeVM.selectedItem, matching: .all(of: [.images]), photoLibrary: .shared())
+    
+    .onChange(of: homeVM.selectedItem) { newItem in
+      Task {
+        if let data = try? await newItem?.loadTransferable(type: Data.self) {
+          homeVM.selectedImageData = data
+          homeVM.getImageFromPhotosPicker()
+          homeVM.saveImage()
+        }
+      }
+    }
   }
   
   private var cameraChatBubble: some View {

--- a/ABloom/ABloom/Presentation/CoreViews/Home/ViewModel/HomeViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Home/ViewModel/HomeViewModel.swift
@@ -85,7 +85,7 @@ final class HomeViewModel: ObservableObject {
   }
   
   // MARK: - 메인 이미지 관련
-  func requestAuthorization() {
+  private func requestAuthorization() {
     guard status == .notDetermined else { return }
     PHPhotoLibrary.requestAuthorization(for: .readWrite) { status in
       // TODO: 요청권한에 따른 처리
@@ -93,7 +93,7 @@ final class HomeViewModel: ObservableObject {
   }
   
   // 파일에서 이미지 가져오기
-  func getImageFromFileManager() {
+  private func getImageFromFileManager() {
     if let image = manager.loadImage(name: saveImageName) {
       self.savedImage = image
     }
@@ -107,13 +107,13 @@ final class HomeViewModel: ObservableObject {
   
   func saveImage() {
     guard let image = savedImage else { return }
-    _ = manager.saveImage(image: image, name: saveImageName)
+    manager.saveImage(image: image, name: saveImageName)
   }
   
   func deleteImage() {
     selectedItem = nil
     selectedImageData = nil
     savedImage = nil
-    _ = manager.deleteImage(name: saveImageName)
+    manager.deleteImage(name: saveImageName)
   }
 }

--- a/ABloom/ABloom/Presentation/CoreViews/Home/ViewModel/HomeViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Home/ViewModel/HomeViewModel.swift
@@ -5,6 +5,7 @@
 //  Created by Lee Jinhee on 10/19/23.
 //
 
+import PhotosUI
 import SwiftUI
 
 @MainActor
@@ -16,6 +17,40 @@ final class HomeViewModel: ObservableObject {
   @Published var partnerType: UserType = .woman
   @Published var recommendQuestion: String = "추천질문입니다"
   @Published var isConnectButtonTapped = false
+  
+  @Published var showDialog = false
+  @Published var showPhotosPicker = false
+  
+  // MARK: 메인 이미지 관련
+  let manager = ImageFileManager.shared
+
+  private let defaultImageName = "HomeDefaultImage"
+  private let saveImageName = "save_main_image"
+  
+  @Published var selectedItem: PhotosPickerItem? = nil
+  @Published var selectedImageData: Data? = nil
+  @Published var savedImage: UIImage? = nil
+  
+  var defaultImage: UIImage {
+    UIImage(named: defaultImageName)!
+  }
+  
+  private var status: PHAuthorizationStatus {
+    PHPhotoLibrary.authorizationStatus(for: .readWrite)
+  }
+  
+  init() {
+    getImageFromFileManager()
+  }
+  
+  func cameraButtonTapped() {
+    showDialog = true
+  }
+  
+  func addImageDialogTapped() {
+    requestAuthorization()
+    showPhotosPicker = true
+  }
   
   func connectButtonTapped() {
     isConnectButtonTapped = true
@@ -47,5 +82,38 @@ final class HomeViewModel: ObservableObject {
     guard let days = Calendar.current.dateComponents([.day], from: today, to: estimatedMarriageDate).day else { return 0 }
     
     return days + 1
+  }
+  
+  // MARK: - 메인 이미지 관련
+  func requestAuthorization() {
+    guard status == .notDetermined else { return }
+    PHPhotoLibrary.requestAuthorization(for: .readWrite) { status in
+      // TODO: 요청권한에 따른 처리
+    }
+  }
+  
+  // 파일에서 이미지 가져오기
+  func getImageFromFileManager() {
+    if let image = manager.loadImage(name: saveImageName) {
+      self.savedImage = image
+    }
+  }
+  
+  func getImageFromPhotosPicker() {
+    if let image = UIImage(data: selectedImageData!) {
+      self.savedImage = image
+    }
+  }
+  
+  func saveImage() {
+    guard let image = savedImage else { return }
+    _ = manager.saveImage(image: image, name: saveImageName)
+  }
+  
+  func deleteImage() {
+    selectedItem = nil
+    selectedImageData = nil
+    savedImage = nil
+    _ = manager.deleteImage(name: saveImageName)
   }
 }


### PR DESCRIPTION
#### related #70

### ✏️ 개요
홈화면의 이미지를 로컬에 저장하고 불러오도록 구현하였습니다.

### 💻 작업 사항
- [x] 로컬 이미지 파일매니저 구현
- [x] 카메라 버튼 클릭시 사진추가하기/사진삭제하기 confirmationDialog 구현 
- [x] 추가한 사진이 없을 경우 DefaultImage 표시
- [x] 포토 라이브러리 접근 권한 설정 
- [x] PhotosPicker 구현 > 필터씌운 이미지 표시
- [x] 사진 삭제기능 구현 

### 📄 리뷰 노트
ImageFileManager를 지금은 Presentation/Home 아래에 넣었는데, 어디에 넣으면 좋을까요?!
Utilities, Classes, Managers 폴더 등,,,

### 📱결과 화면(optional)
<img src = "https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/100195563/0bc7842f-7e98-4a33-b1fa-c970f230458e" width = "250">

<img src = "https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/100195563/a7a95c89-ce4f-4b50-8072-afe0848a3773" width = "250">

<img src = "https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/100195563/13ea5cb9-d9df-4346-bca1-3a7433399a2c" width = "250">

### 📚 ETC(optional)
라이브러리 접근 권한 설정에 따른 분기는 추후 구현 예정입니다 !
