### PR TITLE
[Design/#81] 커스텀 네비게이션바 모디파이어 수정 및 뷰 적용

### DIFF
--- a/ABloom/ABloom.xcodeproj/project.pbxproj
+++ b/ABloom/ABloom.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		605541152ADE1A9D00AD5625 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605541142ADE1A9D00AD5625 /* TabBarView.swift */; };
 		605541172ADE1ACF00AD5625 /* Tab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605541162ADE1ACF00AD5625 /* Tab.swift */; };
 		6055411A2ADE66B000AD5625 /* RegistrationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605541192ADE66B000AD5625 /* RegistrationView.swift */; };
+		607DA20E2AEF48AE005AE11C /* NavigationArrowLeft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607DA20D2AEF48AE005AE11C /* NavigationArrowLeft.swift */; };
 		AE1AE9F92AE50BBC0010089F /* QuestionMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1AE9F82AE50BBC0010089F /* QuestionMainView.swift */; };
 		AE1AE9FB2AE51BF00010089F /* QnAListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1AE9FA2AE51BF00010089F /* QnAListItem.swift */; };
 		AE1AE9FF2AE557E00010089F /* AnswerCheckView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1AE9FE2AE557E00010089F /* AnswerCheckView.swift */; };
@@ -140,6 +141,7 @@
 		605541142ADE1A9D00AD5625 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
 		605541162ADE1ACF00AD5625 /* Tab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tab.swift; sourceTree = "<group>"; };
 		605541192ADE66B000AD5625 /* RegistrationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationView.swift; sourceTree = "<group>"; };
+		607DA20D2AEF48AE005AE11C /* NavigationArrowLeft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationArrowLeft.swift; sourceTree = "<group>"; };
 		AE1AE9F82AE50BBC0010089F /* QuestionMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionMainView.swift; sourceTree = "<group>"; };
 		AE1AE9FA2AE51BF00010089F /* QnAListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QnAListItem.swift; sourceTree = "<group>"; };
 		AE1AE9FE2AE557E00010089F /* AnswerCheckView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerCheckView.swift; sourceTree = "<group>"; };
@@ -423,6 +425,7 @@
 				AEB5026A2AE64B8D0056E439 /* CategoryQuestionBox.swift */,
 				AEEA8DD22AEB82520068550E /* ChatBubbles.swift */,
 				AEB502632AE5FA840056E439 /* CustomNavigationBarModifier.swift */,
+				607DA20D2AEF48AE005AE11C /* NavigationArrowLeft.swift */,
 				6053F1752AE899320064A6E0 /* InputFields.swift */,
 				6053F1612ADF6CDE0064A6E0 /* InputFieldModifier.swift */,
 				AE1AE9FA2AE51BF00010089F /* QnAListItem.swift */,
@@ -726,6 +729,7 @@
 				3DB6A5AB2AE0C09800C1369F /* LoginView.swift in Sources */,
 				3D4412642AE50E8E00FD5A51 /* MyAccountViewModel.swift in Sources */,
 				3D4412802AEACA2A00FD5A51 /* ConnectionWaypointViewModel.swift in Sources */,
+				607DA20E2AEF48AE005AE11C /* NavigationArrowLeft.swift in Sources */,
 				3D4412562AE4F31D00FD5A51 /* MyAccountView.swift in Sources */,
 				AE1AE9FF2AE557E00010089F /* AnswerCheckView.swift in Sources */,
 				AEC260612AEA5A8000DF7CD5 /* StaticQuestionManager.swift in Sources */,

--- a/ABloom/ABloom/Presentation/BoundaryViews/Connection/ConnectionView.swift
+++ b/ABloom/ABloom/Presentation/BoundaryViews/Connection/ConnectionView.swift
@@ -34,25 +34,24 @@ struct ConnectionView: View {
       connectButton
     }
     .padding(.horizontal, 20)
-    .background(backgroundDefault())
     .task {
       try? await connectionVM.getMyCode()
     }
     .customNavigationBar(
       centerView: {
         Text("상대방과 연결")
-          .fontWithTracking(.title3R)
-          .foregroundStyle(.stone700)
       },
       leftView: {
-        Button(action: {dismiss()}, label: {
-          Image("angle-left")
-            .frame(width: 20, height: 20)
-        })
+        Button { 
+          dismiss()
+        } label: {
+          NavigationArrowLeft()
+        }
       },
       rightView: {
         EmptyView()
       })
+    .background(backgroundDefault())
   }
 }
 

--- a/ABloom/ABloom/Presentation/BoundaryViews/Registration/View/RegistrationView.swift
+++ b/ABloom/ABloom/Presentation/BoundaryViews/Registration/View/RegistrationView.swift
@@ -31,8 +31,6 @@ struct RegistrationView: View {
     .customNavigationBar(
       centerView: {
         Text("가입하기")
-          .fontWithTracking(.title3R)
-          .foregroundStyle(.stone700)
       },
       leftView: {
         EmptyView()

--- a/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/Components/EmbedWebView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/Components/EmbedWebView.swift
@@ -8,17 +8,30 @@
 import SwiftUI
 
 struct EmbedWebView: View {
+  @Environment(\.dismiss) private var dismiss
+
   let viewTitle: String
   let urlString: String
   
   var body: some View {
     VStack {
       WebView(urlString: urlString)
+        .padding(.top, 20)
         .ignoresSafeArea(.all, edges: .bottom)
     }
+    .customNavigationBar {
+      Text("\(viewTitle)")
+    } leftView: {
+      Button {
+        print("tapped")
+        dismiss()
+      } label: {
+        NavigationArrowLeft()
+      }
+    } rightView: {
+      EmptyView()
+    }
     .background(backgroundDefault())
-    .navigationTitle(viewTitle)
-    .navigationBarTitleDisplayMode(.inline)
   }
 }
 

--- a/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountView.swift
@@ -9,7 +9,8 @@ import SwiftUI
 
 struct MyAccountView: View {
   let avatarSize: CGFloat = 70
-  
+  @Environment(\.dismiss) private var dismiss
+
   @StateObject var myAccountVM = MyAccountViewModel()
   
   var body: some View {
@@ -25,10 +26,8 @@ struct MyAccountView: View {
     .task {
       try? await myAccountVM.getMyInfo()
     }
-    .navigationTitle("내 계정")
-    .navigationBarTitleDisplayMode(.inline)
+    .tint(.purple600)
     .padding(.horizontal, 25)
-    .background(backgroundDefault())
     .confirmationDialog("정보 변경", isPresented: $myAccountVM.showActionSheet, titleVisibility: .hidden) {
       Button("이름 변경하기", role: .none) {
         myAccountVM.showNameChangeAlert = true
@@ -42,7 +41,18 @@ struct MyAccountView: View {
         myAccountVM.showActionSheet = false
       }
     }
-    .tint(.purple600)
+    .customNavigationBar {
+      Text("내 계정")
+    } leftView: {
+      Button {
+        dismiss()
+      } label: {
+        NavigationArrowLeft()
+      }
+    } rightView: {
+      EmptyView()
+    }
+    .background(backgroundDefault())
   }
 }
 

--- a/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccountConnecting/ConnectedView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccountConnecting/ConnectedView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct ConnectedView: View {
+  @Environment(\.dismiss) private var dismiss
+
   @State var fianceName: String = ""
   
   let fianceId: String
@@ -22,15 +24,24 @@ struct ConnectedView: View {
       Text("\(fianceName)님과 연결되어 있습니다.")
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .navigationTitle("상대방과 연결")
-    .navigationBarTitleDisplayMode(.inline)
-    .background(backgroundDefault())
     .task {
       guard let fianceName = try? await UserManager.shared.getUser(userId: fianceId).name
       else { return }
       
       self.fianceName = fianceName
     }
+    .customNavigationBar {
+      Text("상대방과 연결")
+    } leftView: {
+      Button {
+        dismiss()
+      } label: {
+        NavigationArrowLeft()
+      }
+    } rightView: {
+      EmptyView()
+    }
+    .background(backgroundDefault())
   }
 }
 

--- a/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccountConnecting/MyAccountConnectingView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccountConnecting/MyAccountConnectingView.swift
@@ -29,12 +29,22 @@ struct MyAccountConnectingView: View {
      
       connectButton
     }
-    .navigationTitle("상대방과 연결")
     .padding(.horizontal, 20)
-    .background(backgroundDefault())
     .task {
       try? await myAccountConnectingVM.getMyCode()
     }
+    .customNavigationBar {
+      Text("상대방과 연결")
+    } leftView: {
+      Button {
+        dismiss()
+      } label: {
+        NavigationArrowLeft()
+      }
+    } rightView: {
+      EmptyView()
+    }
+    .background(backgroundDefault())
   }
 }
 

--- a/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/PolicyView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/PolicyView.swift
@@ -9,13 +9,23 @@ import SwiftUI
 
 struct PolicyView: View {
   let listItemPadding: CGFloat = 32
-  
+  @Environment(\.dismiss) private var dismiss
+
   var body: some View {
     menuList
-      .navigationTitle("약관과 정책")
-      .navigationBarTitleDisplayMode(.inline)
       .padding(.horizontal, 20)
       .padding(.top, 24)
+      .customNavigationBar {
+        Text("약관과 정책")
+      } leftView: {
+        Button {
+          dismiss()
+        } label: {
+          NavigationArrowLeft()
+        }
+      } rightView: {
+        EmptyView()
+      }
       .background(backgroundDefault())
   }
 }

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerCheckView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerCheckView.swift
@@ -67,14 +67,13 @@ struct AnswerCheckView: View {
     .customNavigationBar(
       centerView: {
         Text("우리의 문답")
-          .fontWithTracking(.title3R)
-          .foregroundStyle(.stone700)
       },
       leftView: {
-        Button(action: {dismiss()}, label: {
-          Image("angle-left")
-            .frame(width: 20, height: 20)
-        })
+        Button {
+          dismiss()
+        } label: {
+          NavigationArrowLeft()
+        }
       },
       rightView: {
         EmptyView()

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerWriteView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerWriteView.swift
@@ -38,19 +38,16 @@ struct AnswerWriteView: View {
       Text("지금 뒤로 나가면 작성했던 답변이\n삭제되고, 복구할 수 없어요.")
     })
     
-    // 네비게이션바
     .customNavigationBar(
       centerView: {
         Text("문답 작성하기")
-          .fontWithTracking(.title3R)
-          .foregroundStyle(.stone700)
       },
       leftView: {
-        Button(action: answerVM.moveToBack,
-               label: {
-          Image("angle-left")
-            .frame(width: 20, height: 20)
-        })
+        Button {
+          answerVM.moveToBack()
+        } label: {
+          NavigationArrowLeft()
+        }
       },
       rightView: {
         Button {

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/SelectQuestionView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/SelectQuestionView.swift
@@ -32,14 +32,13 @@ struct SelectQuestionView: View {
     .customNavigationBar(
       centerView: {
         Text("질문 선택하기")
-          .fontWithTracking(.title3R)
-          .foregroundStyle(.stone700)
       },
       leftView: {
-        Button(action: {dismiss()}, label: {
-          Image("angle-left")
-            .frame(width: 20, height: 20)
-        })
+        Button {
+          dismiss()
+        } label: {
+          NavigationArrowLeft()
+        }
       },
       rightView: {
         EmptyView()

--- a/ABloom/ABloom/Resources/Components/CustomNavigationBarModifier.swift
+++ b/ABloom/ABloom/Resources/Components/CustomNavigationBarModifier.swift
@@ -37,6 +37,8 @@ struct CustomNavigationBarModifier<C, L, R>: ViewModifier where C: View, L: View
           Spacer()
           
           self.centerView?()
+            .fontWithTracking(.title3R)
+            .foregroundStyle(.stone700)
           
           Spacer()
         }

--- a/ABloom/ABloom/Resources/Components/NavigationArrowLeft.swift
+++ b/ABloom/ABloom/Resources/Components/NavigationArrowLeft.swift
@@ -1,0 +1,17 @@
+//
+//  NavigationArrowLeft.swift
+//  ABloom
+//
+//  Created by Lee Jinhee on 10/30/23.
+//
+
+import SwiftUI
+
+struct NavigationArrowLeft: View {
+  var body: some View {
+    Image("angle-left")
+      .resizable()
+      .scaledToFit()
+      .frame(width: 20, height: 20)
+  }
+}


### PR DESCRIPTION
#### related #81 

### ✏️ 개요
커스텀 네비게이션바 타이틀 모디파이어 수정 밎 모든 뷰에 적용하였습니다.

### 💻 작업 사항
모든 뷰의 네비게이션바 타이틀을 수정하였습니다.

### 📄 리뷰 노트
네비게이션바 모디파이어 아래에 백그라운드모디파이어가 적용되어야해서 순서를 수정했습니다.

### 📱결과 화면(optional)
리뷰어의 이해를 위해 스크린샷을 추가해주세요. 
