### PR TITLE
[Feat/#77] 상대 답변에 따른 답변 메인 화면 로직 구현

### DIFF
--- a/ABloom/ABloom.xcodeproj/project.pbxproj
+++ b/ABloom/ABloom.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		3D957E8C2AEE7F1000D565E9 /* DBUserModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D957E8B2AEE7F1000D565E9 /* DBUserModel.swift */; };
 		3D957E8E2AEE7F2E00D565E9 /* DBStaticQuestionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D957E8D2AEE7F2E00D565E9 /* DBStaticQuestionModel.swift */; };
 		3D957E902AEE7F4800D565E9 /* DBAnswerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D957E8F2AEE7F4800D565E9 /* DBAnswerModel.swift */; };
+		3D957E922AEF527E00D565E9 /* Ex+ Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D957E912AEF527E00D565E9 /* Ex+ Sequence.swift */; };
 		3DB6A5752AE0BDF800C1369F /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5742AE0BDF800C1369F /* FirebaseAnalytics */; };
 		3DB6A5772AE0BDF800C1369F /* FirebaseAnalyticsOnDeviceConversion in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5762AE0BDF800C1369F /* FirebaseAnalyticsOnDeviceConversion */; };
 		3DB6A5792AE0BDF800C1369F /* FirebaseAnalyticsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5782AE0BDF800C1369F /* FirebaseAnalyticsSwift */; };
@@ -125,6 +126,7 @@
 		3D957E8B2AEE7F1000D565E9 /* DBUserModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBUserModel.swift; sourceTree = "<group>"; };
 		3D957E8D2AEE7F2E00D565E9 /* DBStaticQuestionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBStaticQuestionModel.swift; sourceTree = "<group>"; };
 		3D957E8F2AEE7F4800D565E9 /* DBAnswerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBAnswerModel.swift; sourceTree = "<group>"; };
+		3D957E912AEF527E00D565E9 /* Ex+ Sequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Ex+ Sequence.swift"; path = "../../../../../../Desktop/Ex+ Sequence.swift"; sourceTree = "<group>"; };
 		3DB6A5AA2AE0C09800C1369F /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		3DB6A5AD2AE0C12B00C1369F /* AppleLoginButtonViewRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginButtonViewRepresentable.swift; sourceTree = "<group>"; };
 		3DB6A5B02AE11C2D00C1369F /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
@@ -500,6 +502,7 @@
 				AE8D3C502ADE19E0009899A7 /* Ex+Font.swift */,
 				AE8D3C602ADE3C73009899A7 /* Ex+Shape.swift */,
 				3D957E862AEE5C5800D565E9 /* Ex+ Query.swift */,
+				3D957E912AEF527E00D565E9 /* Ex+ Sequence.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -688,6 +691,7 @@
 				3D4412542AE4EE2C00FD5A51 /* MenuListNavigationItem.swift in Sources */,
 				AE8D3C612ADE3C73009899A7 /* Ex+Shape.swift in Sources */,
 				3D4412492AE4C49700FD5A51 /* AuthenticationManager.swift in Sources */,
+				3D957E922AEF527E00D565E9 /* Ex+ Sequence.swift in Sources */,
 				6053F16E2AE179240064A6E0 /* HomeView.swift in Sources */,
 				AE8D3C512ADE19E0009899A7 /* Ex+Font.swift in Sources */,
 				AE8D3C612ADE3C73009899A7 /* Ex+Shape.swift in Sources */,

--- a/ABloom/ABloom/Firebase/Firestore/UserManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/UserManager.swift
@@ -72,7 +72,7 @@ final class UserManager {
     let collection = userAnswerCollection(userId: userId)
     let document = collection.document()
     
-    let data = DBAnswer(questionId: questionId, answerContent: content)
+    let data = DBAnswer(questionId: questionId, userId: userId, answerContent: content)
     
     try? document.setData(from: data, merge: false)
   }

--- a/ABloom/ABloom/Firebase/Model/DBAnswerModel.swift
+++ b/ABloom/ABloom/Firebase/Model/DBAnswerModel.swift
@@ -9,17 +9,20 @@ import Foundation
 
 struct DBAnswer: Codable {
   let questionId: Int
+  let userId: String
   let date: Date
   let answerContent: String
   
-  init(questionId: Int, date: Date = .now, answerContent: String) {
+  init(questionId: Int, userId: String, date: Date = .now, answerContent: String) {
     self.questionId = questionId
+    self.userId = userId
     self.date = date
     self.answerContent = answerContent
   }
   
   enum CodingKeys: String, CodingKey {
     case questionId = "q_id"
+    case userId = "user_id"
     case date = "date"
     case answerContent = "answer_content"
   }
@@ -27,6 +30,7 @@ struct DBAnswer: Codable {
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     self.questionId = try container.decode(Int.self, forKey: .questionId)
+    self.userId = try container.decode(String.self, forKey: .userId)
     self.date = try container.decode(Date.self, forKey: .date)
     self.answerContent = try container.decode(String.self, forKey: .answerContent)
   }
@@ -34,6 +38,7 @@ struct DBAnswer: Codable {
   func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(self.questionId, forKey: .questionId)
+    try container.encode(self.userId, forKey: .userId)
     try container.encode(self.date, forKey: .date)
     try container.encode(self.answerContent, forKey: .answerContent)
   }

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/QuestionMainView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/QuestionMainView.swift
@@ -73,7 +73,7 @@ extension QuestionMainView {
               categoryImg: (Category(rawValue: question.category)?.imgName)!,
               question: question.content,
               date: (questionVM.answers.last(where: { $0.questionId == question.questionID })?.date)!,
-              isAns: false)
+              isAns: questionVM.checkAnswerStatus(qid: question.questionID))
           }
         }
       }

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/QuestionMainView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/QuestionMainView.swift
@@ -17,7 +17,7 @@ struct QuestionMainView: View {
       Spacer()
         .frame(height: 34)
       
-      if questionVM.myAnwsers.isEmpty {
+      if questionVM.answers.isEmpty {
         emptyListView
           .background(backWall())
           
@@ -34,8 +34,8 @@ struct QuestionMainView: View {
       }
     }
     .background(backgroundDefault())
-    .task {
-      try? await questionVM.getMyAnswers()
+    .onAppear {
+      questionVM.getInfo()
     }
   }
 }
@@ -72,7 +72,7 @@ extension QuestionMainView {
             QnAListItem(
               categoryImg: (Category(rawValue: question.category)?.imgName)!,
               question: question.content,
-              date: (questionVM.myAnwsers.first(where: { $0.questionId == question.questionID })?.date)!,
+              date: (questionVM.answers.last(where: { $0.questionId == question.questionID })?.date)!,
               isAns: false)
           }
         }

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/QuestionMainViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/QuestionMainViewModel.swift
@@ -116,12 +116,8 @@ final class QuestionMainViewModel: ObservableObject {
     let myAnswers = try await UserManager.shared.getAnswers(userId: userId)
     let questions = try await StaticQuestionManager.shared.getAnsweredQuestions(questionIds: myAnswers.map({ $0.questionId }))
     
-    myAnswers.forEach { answer in
-      self.answers.append(answer)
-    }
-    questions.forEach { question in
-      self.questions.append(question)
-    }
+    self.answers += myAnswers
+    self.questions += questions
   }
   
   private func getFianceAnswers() async throws {
@@ -130,12 +126,7 @@ final class QuestionMainViewModel: ObservableObject {
     let fianceAnswers = try await UserManager.shared.getAnswers(userId: userId)
     let questions = try await StaticQuestionManager.shared.getAnsweredQuestions(questionIds: fianceAnswers.map({ $0.questionId }))
     
-    fianceAnswers.forEach { answer in
-      self.answers.append(answer)
-    }
-    
-    questions.forEach { question in
-      self.questions.append(question)
-    }
+    self.answers += fianceAnswers
+    self.questions += questions
   }
 }

--- a/ABloom/ABloom/Resources/Components/QnAListItem.swift
+++ b/ABloom/ABloom/Resources/Components/QnAListItem.swift
@@ -7,11 +7,18 @@
 
 import SwiftUI
 
+enum AnswerStatus {
+  case both
+  case onlyMe
+  case onlyFinace
+  case nobody
+}
+
 struct QnAListItem: View {
   let categoryImg: String
   let question: String
   let date: Date
-  let isAns: Bool
+  let isAns: AnswerStatus
   
   var formattedWeddingDate: String {
     let formatter = DateFormatter()
@@ -47,8 +54,16 @@ struct QnAListItem: View {
           
           Spacer()
           
-          Text(isAns ? "" : "답변을 기다리고 있어요 >")
-            .fontWithTracking(.caption2R)
+          switch isAns {
+          case .onlyMe:
+            Text("답변을 기다리고 있어요 >")
+              .fontWithTracking(.caption2R)
+          case .onlyFinace:
+            Text("답변해주세요 >")
+              .fontWithTracking(.caption2R)
+          case .nobody, .both:
+            EmptyView()
+          }
         }
         .foregroundStyle(.stone500)
       }
@@ -56,8 +71,4 @@ struct QnAListItem: View {
     }
     .padding(.horizontal, 20)
   }
-}
-
-#Preview {
-  QnAListItem(categoryImg: "squareIcon_isometric_health", question: "나와 결혼을 결심한 순간은 언제야?", date: .now, isAns: false)
 }


### PR DESCRIPTION
#### close #77

### ✏️ 개요
상대 답변을 메인 화면에 불러오고, 질문의 답변 상태에 따라 뷰 상태를 변경하도록 구현하였습니다.

### 💻 작업 사항
- 상대방 답변 불러오기
- 질문 정렬 및 답변 정렬 (최신 날짜 순)

### 📄 리뷰 노트
- extension 하나 추가했습니다. 배열에서 중복 값 제거하는 함수를 추가했습니다.
- 답변 상태를 enum으로 구현했습니다.
- 정렬 및 필터링 기능을 손수 구현했습니다. 더럽더라도 봐주세요. 🙇‍♂️

### 📱결과 화면(optional)
<img width="511" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/77708819/3a8f2b37-ed1a-4c4e-b6b3-e576f8d5e7d1">
