### PR TITLE
[Feat/80] DB 연관 뷰 로직 수정

### DIFF
--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerCheckView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerCheckView.swift
@@ -11,8 +11,12 @@ struct AnswerCheckView: View {
   @Environment(\.dismiss) private var dismiss
   @StateObject var answerCheckVM: AnswerCheckViewModel
   
+  let gender: Bool
+  
   var body: some View {
     VStack {
+      
+      // 질문 박스
       if let question = answerCheckVM.question {
         CategoryQuestionBox(
           question: question.content,
@@ -25,40 +29,12 @@ struct AnswerCheckView: View {
       Spacer()
         .frame(height: 10)
       
-      // TODO: 데이터의 타임 스탬프를 비교하여, 먼저 작성한 답변이 위로 보여야 함
-      VStack(spacing: 20) {
-        Spacer()
-          .frame(height: 14)
-        
-        RightPinkChatBubble(text: answerCheckVM.myAnswer)
-        
-        
-        HStack(alignment: .top, spacing: 13) {
-          Image("avatar_Male circle GradientBG")
-            .resizable()
-            .frame(width: 34, height: 34)
-          
-          // TODO: 성별에 따른 색상 구분
-          LeftBlueChatBubble(text: answerCheckVM.fianceAnswer.isEmpty ? "상대방의 답변을 기다리고 있어요." : answerCheckVM.fianceAnswer)
-          
-          // TODO: 답변 상태에 따른 메세지 로직 구현 필요 @Lia
-          if answerCheckVM.isNoFiance {
-            LeftBlueChatBubble(text: "상대 없음")
-          }
-          
-          if answerCheckVM.isNoFianceAnswer {
-            LeftBlueChatBubble(text: "상대 답변 없음 ")
-          }
-          
-          if answerCheckVM.isNoMyAnswer {
-            LeftBlueChatBubble(text: "내 답변 없음")
-          }
-        }
-        
-        Spacer()
+      // 남성 일 경우
+      if gender {
+        malePart
+      } else { // 여성 일 경우
+        femalePart
       }
-      .padding(.horizontal, 20)
-      .background(backWall())
     }
     .onAppear {
       answerCheckVM.getAnswers()
@@ -85,6 +61,105 @@ struct AnswerCheckView: View {
   }
 }
 
+
+extension AnswerCheckView {
+  
+  private var malePart: some View {
+    VStack(spacing: 20) {
+      Spacer()
+        .frame(height: 14)
+      // if 상대방과의 연결이 없을 경우
+      if answerCheckVM.isNoFiance {
+        if !answerCheckVM.isNoMyAnswer {
+          RightBlueChatBubble(text: answerCheckVM.myAnswer)
+        }
+        LeftPinkChatBubbleWithImg(text: "아직 상대방과 연결되어 있지 않아요. 지금 연결하고, 상대방의 문답을 확인해주세요.")
+        NavigationLink {
+          // 연결하는 뷰로 이동
+        } label: {
+          LeftPinkChatBubble(text: "연결하기  >", isBold: true)
+        }
+        
+        // if 내가 먼저 답하고, 상대방의 답변을 기다릴 경우
+      } else if answerCheckVM.isNoFianceAnswer && !answerCheckVM.isNoMyAnswer {
+        RightBlueChatBubble(text: answerCheckVM.myAnswer)
+        LeftPinkChatBubbleWithImg(text: "상대방의 답변을 기다리고 있어요.")
+      }
+      
+      // if 상대방이 답하고, 상대방이 내 답변을 기다릴 경우 => 내비게이션 연결
+      else if !answerCheckVM.isNoFianceAnswer && answerCheckVM.isNoMyAnswer {
+        LeftPinkChatBubbleWithImg(text: "(상대방 이름)님이 답변을 등록했어요. 답변을 확인해보려면 나의 문답을 작성해주세요.")
+        NavigationLink {
+          if let question = answerCheckVM.question {
+            AnswerWriteView(question: question)
+          }
+        } label: {
+          RightBlueChatBubble(text: "문답 작성하기  >", isBold: true)
+        }
+      }
+      
+      // 둘 다 작성했을 경우
+      // TODO: 누구의 답변이 먼저인지 로직 파악 필요
+      else {
+        RightBlueChatBubble(text: answerCheckVM.myAnswer)
+        LeftPinkChatBubbleWithImg(text: answerCheckVM.fianceAnswer)
+      }
+      
+      Spacer()
+    }
+    .padding(.horizontal, 20)
+    .background(backWall())
+  }
+  
+  private var femalePart: some View {
+    // 답변 확인 뷰
+    VStack(spacing: 20) {
+      Spacer()
+        .frame(height: 14)
+      
+      // if 상대방과의 연결이 없을 경우
+      if answerCheckVM.isNoFiance {
+        if !answerCheckVM.isNoMyAnswer {
+          RightPinkChatBubble(text: answerCheckVM.myAnswer)
+        }
+        LeftBlueChatBubbleWithImg(text: "아직 상대방과 연결되어 있지 않아요. 지금 연결하고, 상대방의 문답을 확인해주세요.")
+        NavigationLink {
+          // TODO: 연결하는 뷰로 이동
+        } label: {
+          LeftBlueChatBubble(text: "연결하기  >", isBold: true)
+        }
+        
+        // if 내가 먼저 답하고, 상대방의 답변을 기다릴 경우
+      } else if answerCheckVM.isNoFianceAnswer && !answerCheckVM.isNoMyAnswer {
+        RightPinkChatBubble(text: answerCheckVM.myAnswer)
+        LeftBlueChatBubbleWithImg(text: "상대방의 답변을 기다리고 있어요.")
+      }
+      
+      // if 상대방이 답하고, 상대방이 내 답변을 기다릴 경우 => 내비게이션 연결
+      else if !answerCheckVM.isNoFianceAnswer && answerCheckVM.isNoMyAnswer {
+        LeftBlueChatBubbleWithImg(text: "(상대방 이름)님이 답변을 등록했어요. 답변을 확인해보려면 나의 문답을 작성해주세요.")
+        NavigationLink {
+          if let question = answerCheckVM.question {
+            AnswerWriteView(question: question)
+          }
+        } label: {
+          RightPinkChatBubble(text: "문답 작성하기  >", isBold: true)
+        }
+      }
+      
+      // 둘 다 작성했을 경우
+      // TODO: 누구의 답변이 먼저인지 로직 파악 필요
+      else {
+        RightBlueChatBubble(text: answerCheckVM.myAnswer)
+        LeftPinkChatBubbleWithImg(text: answerCheckVM.fianceAnswer)
+      }
+      Spacer()
+    }
+    .padding(.horizontal, 20)
+    .background(backWall())
+  }
+}
+
 #Preview {
-  AnswerCheckView(answerCheckVM: .init(questionId: 1))
+  AnswerCheckView(answerCheckVM: .init(questionId: 3), gender: true)
 }

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerCheckView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerCheckView.swift
@@ -11,7 +11,7 @@ struct AnswerCheckView: View {
   @Environment(\.dismiss) private var dismiss
   @StateObject var answerCheckVM: AnswerCheckViewModel
   
-  let gender: Bool
+  let sex: Bool
   
   var body: some View {
     VStack {
@@ -30,7 +30,7 @@ struct AnswerCheckView: View {
         .frame(height: 10)
       
       // 남성 일 경우
-      if gender {
+      if sex {
         malePart
       } else { // 여성 일 경우
         femalePart
@@ -98,8 +98,7 @@ extension AnswerCheckView {
         }
       }
       
-      // 둘 다 작성했을 경우
-      // TODO: 누구의 답변이 먼저인지 로직 파악 필요
+      // 둘 다 작성했을 경우 => 내 답변이 먼저 보이기
       else {
         RightBlueChatBubble(text: answerCheckVM.myAnswer)
         LeftPinkChatBubbleWithImg(text: answerCheckVM.fianceAnswer)
@@ -147,8 +146,7 @@ extension AnswerCheckView {
         }
       }
       
-      // 둘 다 작성했을 경우
-      // TODO: 누구의 답변이 먼저인지 로직 파악 필요
+      // 둘 다 작성했을 경우 => 내 답변이 먼저 보이기
       else {
         RightBlueChatBubble(text: answerCheckVM.myAnswer)
         LeftPinkChatBubbleWithImg(text: answerCheckVM.fianceAnswer)
@@ -161,5 +159,5 @@ extension AnswerCheckView {
 }
 
 #Preview {
-  AnswerCheckView(answerCheckVM: .init(questionId: 3), gender: true)
+  AnswerCheckView(answerCheckVM: .init(questionId: 3), sex: true)
 }

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerCheckView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerCheckView.swift
@@ -147,8 +147,8 @@ extension AnswerCheckView {
       
       // 둘 다 작성했을 경우 => 내 답변이 먼저 보이기
       else {
-        RightBlueChatBubble(text: answerCheckVM.myAnswer)
-        LeftPinkChatBubbleWithImg(text: answerCheckVM.fianceAnswer)
+        RightPinkChatBubble(text: answerCheckVM.myAnswer)
+        LeftBlueChatBubbleWithImg(text: answerCheckVM.fianceAnswer)
       }
       Spacer()
     }

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerWriteView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerWriteView.swift
@@ -39,7 +39,7 @@ struct AnswerWriteView: View {
     })
     
     .task {
-      try? await answerVM.getUserGender()
+      try? await answerVM.getUserSex()
     }
     
     // 네비게이션바
@@ -76,7 +76,7 @@ extension AnswerWriteView {
     HStack(alignment: .top, spacing: 11) {
       
       // 유저가 남성일 때,
-      if answerVM.gender {
+      if answerVM.sex {
         Image("avatar_Female circle GradientBG")
           .resizable()
           .frame(width: 34, height: 34)
@@ -106,7 +106,7 @@ extension AnswerWriteView {
     HStack {
       Spacer()
       
-      if answerVM.gender {
+      if answerVM.sex {
         BlueChatBubbleTextField(text: $answerVM.answerText)
           .onChange(of: answerVM.answerText, perform: { newValue in
             if newValue.count > 150 {

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerWriteView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerWriteView.swift
@@ -9,8 +9,8 @@ import SwiftUI
 
 struct AnswerWriteView: View {
   var question: DBStaticQuestion
-  @StateObject var answerVM = AnswerWriteViewModel()
   
+  @StateObject var answerVM = AnswerWriteViewModel()
   @Environment(\.dismiss) private var dismiss
   
   var body: some View {
@@ -38,6 +38,10 @@ struct AnswerWriteView: View {
       Text("지금 뒤로 나가면 작성했던 답변이\n삭제되고, 복구할 수 없어요.")
     })
     
+    .task {
+      try? await answerVM.getUserGender()
+    }
+    
     // 네비게이션바
     .customNavigationBar(
       centerView: {
@@ -46,8 +50,7 @@ struct AnswerWriteView: View {
           .foregroundStyle(.stone700)
       },
       leftView: {
-        Button(action: answerVM.moveToBack,
-               label: {
+        Button(action: answerVM.moveToBack, label: {
           Image("angle-left")
             .frame(width: 20, height: 20)
         })
@@ -73,24 +76,25 @@ extension AnswerWriteView {
     HStack(alignment: .top, spacing: 11) {
       
       // 유저가 남성일 때,
-      //      Image("avatar_Female circle GradientBG")
-      //        .resizable()
-      //        .frame(width: 34, height: 34)
-      //
-      //      VStack {
-      //        LeftPinkChatBubble(text: question.content)
-      //        LeftPinkChatBubble(text: "너의 생각을 알려줘")
-      //      }
-      
-      
-      // 유저가 여성일 떄,
-      Image("avatar_Male circle GradientBG")
-        .resizable()
-        .frame(width: 34, height: 34)
-      
-      VStack {
-        LeftBlueChatBubble(text: question.content)
-        LeftBlueChatBubble(text: "너의 생각을 알려줘")
+      if answerVM.gender {
+        Image("avatar_Female circle GradientBG")
+          .resizable()
+          .frame(width: 34, height: 34)
+        
+        VStack {
+          LeftPinkChatBubble(text: question.content)
+          LeftPinkChatBubble(text: "너의 생각을 알려줘")
+        }
+        // 유저가 여성일 떄,
+      } else {
+        Image("avatar_Male circle GradientBG")
+          .resizable()
+          .frame(width: 34, height: 34)
+        
+        VStack {
+          LeftBlueChatBubble(text: question.content)
+          LeftBlueChatBubble(text: "너의 생각을 알려줘")
+        }
       }
       
       Spacer()
@@ -102,18 +106,24 @@ extension AnswerWriteView {
     HStack {
       Spacer()
       
-      // 유저가 남성일 때,
-      // BlueChatBubbleTextField(text: $answerVM.answerText)
+      if answerVM.gender {
+        BlueChatBubbleTextField(text: $answerVM.answerText)
+          .onChange(of: answerVM.answerText, perform: { newValue in
+            if newValue.count > 150 {
+              answerVM.answerText = String(newValue.prefix(150))
+            }
+          })
+          .padding(.horizontal, 22)
+      } else {
+        PinkChatBubbleTextField(text: $answerVM.answerText)
+          .onChange(of: answerVM.answerText, perform: { newValue in
+            if newValue.count > 150 {
+              answerVM.answerText = String(newValue.prefix(150))
+            }
+          })
+          .padding(.horizontal, 22)
+      }
       
-      // 유저가 여성일 떄,
-      PinkChatBubbleTextField(text: $answerVM.answerText)
-      
-        .onChange(of: answerVM.answerText, perform: { newValue in
-        if newValue.count > 150 {
-            answerVM.answerText = String(newValue.prefix(150))
-        }
-        })
-        .padding(.horizontal, 22)
     }
   }
 }

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/QuestionMainView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/QuestionMainView.swift
@@ -23,19 +23,19 @@ struct QuestionMainView: View {
         
       } else {
         answeredQScroll
-          .navigationDestination(for: Int.self, destination: { content in
-            if content == 0 {
-              SelectQuestionView(gender: questionVM.gender)
-            } else {
-              AnswerCheckView(answerCheckVM: .init(questionId: content), gender: questionVM.gender)
-            }
-          })
           .background(backWall())
       }
     }
+    .navigationDestination(for: Int.self, destination: { content in
+      if content == 0 {
+        SelectQuestionView(gender: questionVM.sex)
+      } else {
+        AnswerCheckView(answerCheckVM: .init(questionId: content), sex: questionVM.sex)
+      }
+    })
     .background(backgroundDefault())
     .task {
-      try? await questionVM.getUserGender()
+      try? await questionVM.getUserSex()
       try? await questionVM.getMyAnswers()
       
     }

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/QuestionMainView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/QuestionMainView.swift
@@ -20,14 +20,14 @@ struct QuestionMainView: View {
       if questionVM.myAnwsers.isEmpty {
         emptyListView
           .background(backWall())
-          
+        
       } else {
         answeredQScroll
           .navigationDestination(for: Int.self, destination: { content in
             if content == 0 {
-              SelectQuestionView()
+              SelectQuestionView(gender: questionVM.gender)
             } else {
-              AnswerCheckView(answerCheckVM: .init(questionId: content))
+              AnswerCheckView(answerCheckVM: .init(questionId: content), gender: questionVM.gender)
             }
           })
           .background(backWall())
@@ -35,7 +35,9 @@ struct QuestionMainView: View {
     }
     .background(backgroundDefault())
     .task {
+      try? await questionVM.getUserGender()
       try? await questionVM.getMyAnswers()
+      
     }
   }
 }

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/SelectQuestionView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/SelectQuestionView.swift
@@ -9,8 +9,9 @@ import SwiftUI
 
 struct SelectQuestionView: View {
   @Environment(\.dismiss) private var dismiss
-  
   @StateObject var selectQVM = SelectQuestionViewModel()
+  
+  let gender: Bool
   
   var body: some View {
     VStack {
@@ -55,11 +56,14 @@ extension SelectQuestionView {
   private var categoryBar: some View {
     ScrollView(.horizontal, showsIndicators: false) {
       HStack(spacing: 16) {
+        
         ForEach(Category.allCases, id: \.self) { category in
           VStack(alignment: .center, spacing: 6) {
+            
             Image(category.imgName)
               .resizable()
               .frame(width: 64, height: 64)
+            
             Text(category.type)
               .fontWithTracking(selectQVM.selectedCategory == category ? .caption1Bold : .caption1R)
               .foregroundStyle(.stone700)
@@ -93,7 +97,11 @@ extension SelectQuestionView {
       ScrollView(.vertical) {
         ForEach(selectQVM.filteredLists, id: \.self) { question in
           NavigationLink(value: question) {
-            LeftBlueChatBubble(text: question.content)
+            if gender {
+              LeftPinkChatBubble(text: question.content)
+            } else {
+              LeftBlueChatBubble(text: question.content)
+            }
           }
           .padding(.horizontal, 20)
           .padding(.bottom, 12)
@@ -104,5 +112,5 @@ extension SelectQuestionView {
 }
 
 #Preview {
-  SelectQuestionView()
+  SelectQuestionView(gender: false)
 }

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/AnswerWriteViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/AnswerWriteViewModel.swift
@@ -7,9 +7,22 @@
 
 import SwiftUI
 
-class AnswerWriteViewModel: ObservableObject {
+@MainActor
+final class AnswerWriteViewModel: ObservableObject {
   @Published var answerText: String = ""
   @Published var isAlertOn: Bool = false
+  @Published var gender = Bool()
+  
+  
+  func getUserGender() async throws {
+    let userId = try AuthenticationManager.shared.getAuthenticatedUser().uid
+    
+    let gender = try await UserManager.shared.getUser(userId: userId).sex
+    
+    // 0 = female, 1 = male
+    self.gender = gender!
+  }
+  
   
   func moveToBack() {
     isAlertOn = true

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/AnswerWriteViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/AnswerWriteViewModel.swift
@@ -11,16 +11,16 @@ import SwiftUI
 final class AnswerWriteViewModel: ObservableObject {
   @Published var answerText: String = ""
   @Published var isAlertOn: Bool = false
-  @Published var gender = Bool()
+  @Published var sex = Bool()
   
   
-  func getUserGender() async throws {
+  func getUserSex() async throws {
     let userId = try AuthenticationManager.shared.getAuthenticatedUser().uid
     
-    let gender = try await UserManager.shared.getUser(userId: userId).sex
+    let sex = try await UserManager.shared.getUser(userId: userId).sex
     
     // 0 = female, 1 = male
-    self.gender = gender!
+    self.sex = sex!
   }
   
   

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/QuestionMainViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/QuestionMainViewModel.swift
@@ -53,6 +53,17 @@ enum Category: String, CaseIterable {
 final class QuestionMainViewModel: ObservableObject {
   @Published var myAnwsers: [DBAnswer] = []
   @Published var questions: [DBStaticQuestion] = []
+  @Published var gender = Bool()
+  
+  
+  func getUserGender() async throws {
+    let userId = try AuthenticationManager.shared.getAuthenticatedUser().uid
+    
+    let gender = try await UserManager.shared.getUser(userId: userId).sex
+    
+    // 0 = female, 1 = male
+    self.gender = gender!
+  }
   
   func getMyAnswers() async throws {
     let userId = try AuthenticationManager.shared.getAuthenticatedUser().uid

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/QuestionMainViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/QuestionMainViewModel.swift
@@ -53,16 +53,16 @@ enum Category: String, CaseIterable {
 final class QuestionMainViewModel: ObservableObject {
   @Published var myAnwsers: [DBAnswer] = []
   @Published var questions: [DBStaticQuestion] = []
-  @Published var gender = Bool()
+  @Published var sex = Bool()
   
   
-  func getUserGender() async throws {
+  func getUserSex() async throws {
     let userId = try AuthenticationManager.shared.getAuthenticatedUser().uid
     
-    let gender = try await UserManager.shared.getUser(userId: userId).sex
+    let sex = try await UserManager.shared.getUser(userId: userId).sex
     
     // 0 = female, 1 = male
-    self.gender = gender!
+    self.sex = sex!
   }
   
   func getMyAnswers() async throws {

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/SelectQuestionViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/SelectQuestionViewModel.swift
@@ -14,18 +14,16 @@ final class SelectQuestionViewModel: ObservableObject {
   @Published var filteredLists = [DBStaticQuestion]()
   @Published var selectedCategory: Category = Category.values
   
-  @Published var gender = Bool()
+  @Published var sex = Bool()
   
-  
-  func getUserGender() async throws {
+  func getUserSex() async throws {
     let userId = try AuthenticationManager.shared.getAuthenticatedUser().uid
     
-    let gender = try await UserManager.shared.getUser(userId: userId).sex
+    let sex = try await UserManager.shared.getUser(userId: userId).sex
     
     // 0 = female, 1 = male
-    self.gender = gender!
+    self.sex = sex!
   }
-  
   
   func selectCategory(seleted: Category) {
     selectedCategory = seleted

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/SelectQuestionViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/SelectQuestionViewModel.swift
@@ -14,6 +14,19 @@ final class SelectQuestionViewModel: ObservableObject {
   @Published var filteredLists = [DBStaticQuestion]()
   @Published var selectedCategory: Category = Category.values
   
+  @Published var gender = Bool()
+  
+  
+  func getUserGender() async throws {
+    let userId = try AuthenticationManager.shared.getAuthenticatedUser().uid
+    
+    let gender = try await UserManager.shared.getUser(userId: userId).sex
+    
+    // 0 = female, 1 = male
+    self.gender = gender!
+  }
+  
+  
   func selectCategory(seleted: Category) {
     selectedCategory = seleted
     filterQuestion()

--- a/ABloom/ABloom/Resources/Components/CategoryQuestionBox.swift
+++ b/ABloom/ABloom/Resources/Components/CategoryQuestionBox.swift
@@ -27,10 +27,11 @@ struct CategoryQuestionBox: View {
       
       Text("\"\(question)\"")
         .fontWithTracking(.subHeadlineR)
+        .multilineTextAlignment(.center)
         .padding(.bottom, 22)
     }
     .frame(maxWidth: .infinity)
-    .frame(height: 104)
+    .frame(minHeight: 104)
     .background(
       RoundedRectangle(cornerRadius: 20)
         .foregroundStyle(.white)

--- a/ABloom/ABloom/Resources/Components/ChatBubbles.swift
+++ b/ABloom/ABloom/Resources/Components/ChatBubbles.swift
@@ -177,7 +177,7 @@ struct LeftBlueChatBubbleWithImg: View {
   }
 }
 
-// MARK: -TextField ChatBubbles
+// MARK: - TextField ChatBubbles
 
 struct BlueChatBubbleTextField: View {
   @Binding var text: String

--- a/ABloom/ABloom/Resources/Components/ChatBubbles.swift
+++ b/ABloom/ABloom/Resources/Components/ChatBubbles.swift
@@ -7,27 +7,30 @@
 
 import SwiftUI
 
-/*
- Customized Chat Bubble structs
- 
- - 가로 길이는 고정, 세로 길이는 글자 입력에 따라 늘어날 수 있도록 조정
- - 텍스트 중앙 정렬, 여러 줄일 때는 leading
- 
- <참고사항>
- - background()와의 간격을 위해 background() 이전 padding(5) 고려
- => 디자인 사이즈 조절로 벤틀리와 상의 후 추가 예정
- - Figma에 Radius가 명시되어 있지 않아 확정 필요
- */
+// Customized Chat Bubbles
 
 let paddingV = 10.0
 
 struct LeftBlueChatBubble: View {
   let text: String
+  let isBold: Bool
+  
+  init(text: String) {
+    self.text = text
+    self.isBold = false
+  }
+  
+  init(text: String, isBold: Bool) {
+    self.text = text
+    self.isBold = isBold
+  }
   
   var body: some View {
     HStack {
+      Spacer()
+      
       Text(text)
-        .fontWithTracking(.footnoteR, tracking: -0.4)
+        .fontWithTracking(isBold ? .footnoteBold : .footnoteR, tracking: -0.4)
         .foregroundStyle(.stone900)
         .padding(paddingV)
         .multilineTextAlignment(.leading)
@@ -44,15 +47,61 @@ struct LeftBlueChatBubble: View {
   }
 }
 
-struct RightBlueChatBubble: View {
+struct LeftPinkChatBubble: View {
   let text: String
+  let isBold: Bool
+  
+  init(text: String) {
+    self.text = text
+    self.isBold = false
+  }
+  
+  init(text: String, isBold: Bool) {
+    self.text = text
+    self.isBold = isBold
+  }
   
   var body: some View {
     HStack {
       Spacer()
       
       Text(text)
-        .fontWithTracking(.footnoteR, tracking: -0.4)
+        .fontWithTracking(isBold ? .footnoteBold : .footnoteR, tracking: -0.4)
+        .foregroundStyle(.stone900)
+        .padding(paddingV)
+        .background(
+          Rectangle()
+            .foregroundStyle(.pink100)
+            .cornerRadius(10, corners: [.topRight, .bottomRight, .bottomLeft])
+        )
+        .frame(minHeight: 20, alignment: .center)
+        .frame(maxWidth: .infinity, alignment: .leading)
+      
+      Spacer()
+    }
+  }
+}
+
+struct RightBlueChatBubble: View {
+  let text: String
+  let isBold: Bool
+  
+  init(text: String) {
+    self.text = text
+    self.isBold = false
+  }
+  
+  init(text: String, isBold: Bool) {
+    self.text = text
+    self.isBold = isBold
+  }
+  
+  var body: some View {
+    HStack {
+      Spacer()
+      
+      Text(text)
+        .fontWithTracking(isBold ? .footnoteBold : .footnoteR, tracking: -0.4)
         .foregroundStyle(.stone900)
         .padding(paddingV)
         .background(
@@ -66,38 +115,27 @@ struct RightBlueChatBubble: View {
   }
 }
 
-struct LeftPinkChatBubble: View {
-  let text: String
-  
-  var body: some View {
-    HStack {
-      
-      Text(text)
-        .fontWithTracking(.footnoteR, tracking: -0.4)
-        .foregroundStyle(.stone900)
-        .padding(paddingV)
-        .background(
-          Rectangle()
-            .foregroundStyle(.pink100)
-            .cornerRadius(10, corners: [.topRight, .bottomRight, .bottomLeft])
-        )
-        .frame(minHeight: 16, alignment: .center)
-        .frame(maxWidth: 270, alignment: .leading)
-      
-      Spacer()
-    }
-  }
-}
-
 struct RightPinkChatBubble: View {
   let text: String
+  let isBold: Bool
+  
+  init(text: String) {
+    self.text = text
+    self.isBold = false
+  }
+  
+  init(text: String, isBold: Bool) {
+    self.text = text
+    self.isBold = isBold
+  }
+  
   
   var body: some View {
     HStack {
       Spacer()
       
       Text(text)
-        .fontWithTracking(.footnoteR, tracking: -0.4)
+        .fontWithTracking(isBold ? .footnoteBold : .footnoteR, tracking: -0.4)
         .foregroundStyle(.stone900)
         .padding(paddingV)
         .background(
@@ -110,6 +148,36 @@ struct RightPinkChatBubble: View {
     }
   }
 }
+
+// MARK: - ChatBubbles with Imgs
+
+struct LeftPinkChatBubbleWithImg: View {
+  let text: String
+  
+  var body: some View {
+    HStack(alignment: .top, spacing: 13) {
+      Image("avatar_Female circle GradientBG")
+        .resizable()
+        .frame(width: 34, height: 34)
+      LeftPinkChatBubble(text: text)
+    }
+  }
+}
+
+struct LeftBlueChatBubbleWithImg: View {
+  let text: String
+  
+  var body: some View {
+    HStack(alignment: .top, spacing: 13) {
+      Image("avatar_Male circle GradientBG")
+        .resizable()
+        .frame(width: 34, height: 34)
+      LeftBlueChatBubble(text: text)
+    }
+  }
+}
+
+// MARK: -TextField ChatBubbles
 
 struct BlueChatBubbleTextField: View {
   @Binding var text: String
@@ -137,7 +205,7 @@ struct BlueChatBubbleTextField: View {
       )
       .frame(minHeight: 30, alignment: .center)
       .frame(width: 242, alignment: .center)
-     
+    
   }
 }
 
@@ -168,7 +236,6 @@ struct PinkChatBubbleTextField: View {
       .frame(minHeight: 30, alignment: .center)
       .frame(width: 242, alignment: .center)
   }
-  
 }
 
 #Preview {


### PR DESCRIPTION
#### close #80

### ✏️ 개요
- DB 연결 로직을 문답 뷰와 연결

### 💻 작업 사항
- ChatBubble 컴포넌트 생성 및 수정
- User의 성별 가지고 오기
- 성별 및 답변 현황에 따라서 뷰 구현하기

### 📄 리뷰 노트
User 성별 가지고 올 때, AnswerWriteView에 파라미터로 넘길 시 버그가 발생했습니다. 네비게이션에 해당하는 버그 같아서 로직 상의 문제가 아니라, AnswerWriteViewModel에서도 똑같이 유저 성별을 가지고 오는 함수를 구현해 두었습니다.

챗버블 코드 내부에서 마크 주석으로 분리해두었는데, 나중에 정리해보겠습니다!

### 📱결과 화면(optional)
상황 별로 달라서 규니 로직과 합친 이후 확인해 보겠습니다!

### 📚 ETC(optional)
X
