### PR TITLE
[Design/83] 회원탈퇴 뷰 레이아웃 구현

### DIFF
--- a/ABloom/ABloom.xcodeproj/project.pbxproj
+++ b/ABloom/ABloom.xcodeproj/project.pbxproj
@@ -73,8 +73,9 @@
 		605541152ADE1A9D00AD5625 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605541142ADE1A9D00AD5625 /* TabBarView.swift */; };
 		605541172ADE1ACF00AD5625 /* Tab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605541162ADE1ACF00AD5625 /* Tab.swift */; };
 		6055411A2ADE66B000AD5625 /* RegistrationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605541192ADE66B000AD5625 /* RegistrationView.swift */; };
-		607DA20E2AEF48AE005AE11C /* NavigationArrowLeft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607DA20D2AEF48AE005AE11C /* NavigationArrowLeft.swift */; };
 		607DA20C2AEE5028005AE11C /* ImageFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607DA20B2AEE5028005AE11C /* ImageFileManager.swift */; };
+		607DA20E2AEF48AE005AE11C /* NavigationArrowLeft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607DA20D2AEF48AE005AE11C /* NavigationArrowLeft.swift */; };
+		607DA2122AEF5C96005AE11C /* DeleteAccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607DA2112AEF5C96005AE11C /* DeleteAccountView.swift */; };
 		AE1AE9F92AE50BBC0010089F /* QuestionMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1AE9F82AE50BBC0010089F /* QuestionMainView.swift */; };
 		AE1AE9FB2AE51BF00010089F /* QnAListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1AE9FA2AE51BF00010089F /* QnAListItem.swift */; };
 		AE1AE9FF2AE557E00010089F /* AnswerCheckView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1AE9FE2AE557E00010089F /* AnswerCheckView.swift */; };
@@ -142,8 +143,9 @@
 		605541142ADE1A9D00AD5625 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
 		605541162ADE1ACF00AD5625 /* Tab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tab.swift; sourceTree = "<group>"; };
 		605541192ADE66B000AD5625 /* RegistrationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationView.swift; sourceTree = "<group>"; };
-		607DA20D2AEF48AE005AE11C /* NavigationArrowLeft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationArrowLeft.swift; sourceTree = "<group>"; };
 		607DA20B2AEE5028005AE11C /* ImageFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFileManager.swift; sourceTree = "<group>"; };
+		607DA20D2AEF48AE005AE11C /* NavigationArrowLeft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationArrowLeft.swift; sourceTree = "<group>"; };
+		607DA2112AEF5C96005AE11C /* DeleteAccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAccountView.swift; sourceTree = "<group>"; };
 		AE1AE9F82AE50BBC0010089F /* QuestionMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionMainView.swift; sourceTree = "<group>"; };
 		AE1AE9FA2AE51BF00010089F /* QnAListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QnAListItem.swift; sourceTree = "<group>"; };
 		AE1AE9FE2AE557E00010089F /* AnswerCheckView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerCheckView.swift; sourceTree = "<group>"; };
@@ -255,6 +257,7 @@
 			children = (
 				3D4412552AE4F31D00FD5A51 /* MyAccountView.swift */,
 				3D4412632AE50E8E00FD5A51 /* MyAccountViewModel.swift */,
+				607DA2112AEF5C96005AE11C /* DeleteAccountView.swift */,
 			);
 			path = MyAccount;
 			sourceTree = "<group>";
@@ -731,6 +734,7 @@
 				3D4412512AE4E58A00FD5A51 /* MenuView.swift in Sources */,
 				3DB6A5B42AE11CCD00C1369F /* SignInAppleHelper.swift in Sources */,
 				3DB6A5AB2AE0C09800C1369F /* LoginView.swift in Sources */,
+				607DA2122AEF5C96005AE11C /* DeleteAccountView.swift in Sources */,
 				3D4412642AE50E8E00FD5A51 /* MyAccountViewModel.swift in Sources */,
 				3D4412802AEACA2A00FD5A51 /* ConnectionWaypointViewModel.swift in Sources */,
 				607DA20E2AEF48AE005AE11C /* NavigationArrowLeft.swift in Sources */,

--- a/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/DeleteAccountView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/DeleteAccountView.swift
@@ -1,0 +1,62 @@
+//
+//  DeleteAccountView.swift
+//  ABloom
+//
+//  Created by Lee Jinhee on 10/30/23.
+//
+
+import SwiftUI
+
+struct DeleteAccountView: View {
+  @Environment(\.dismiss) private var dismiss
+
+  private let title = "메리를 탈퇴하시나요?"
+  private let content1 = "지금까지 메리를 이용해주셔서 감사합니다.\n회원님께 더 나은 서비스를 제공해드리지 못한 것 같아 무거운 마음이 큽니다.\n\n"
+  private let content2 = "이제 탈퇴하기를 누르시면 회원탈퇴가 진행되며, 저장된 개인정보가 안전하게 삭제되고 연결되어있던 상대방과의 연결이 자동으로 해제됩니다.\n\n"
+  private let content3 = "앞으로 계속 노력하고 발전하는 메리가 되어 회원님을 다시 만날 수 있기를 바라며, 회원님의 앞날을 항상 응원하겠습니다."
+  
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      Text(title)
+        .foregroundStyle(.stone900)
+        .fontWithTracking(.title3Bold)
+        .padding(.bottom, 18)
+      Text(content1 + content2 + content3)
+        .foregroundStyle(.stone700)
+        .fontWithTracking(.subHeadlineR, tracking: -0.4)
+      
+      Spacer()
+      
+      Button {
+      // TODO: 회원탈퇴 & 로그인뷰 이동
+      } label: {
+        StoneSingleBtn(text: "탈퇴하기")
+      }
+      .padding(.bottom, 20)
+      
+      // TODO: NavigationStack 초기화로 리팩토링
+      NavigationLink(destination: HomeView()) {
+        PurpleSingleBtn(text: "다시 사용하기")
+      }
+    }
+    .padding(.top, 54)
+    .padding(.horizontal, 20)
+    .customNavigationBar(centerView: {
+      Text("회원 탈퇴")
+    }, leftView: {
+      Button {
+        dismiss()
+      } label: {
+        NavigationArrowLeft()
+      }
+    }, rightView: {
+      EmptyView()
+    })
+    .background(backgroundDefault())
+    .padding(.bottom, 40)
+  }
+}
+
+#Preview {
+  DeleteAccountView()
+}

--- a/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountView.swift
@@ -141,7 +141,7 @@ extension MyAccountView {
       }
       
       MenuListNavigationItem(title: "회원탈퇴") {
-        Text("회원탈퇴")
+        DeleteAccountView()
       }
     }
     .alert("로그아웃 하시겠어요?", isPresented: $myAccountVM.showSignOutCheckAlert) {

--- a/ABloom/ABloom/Resources/Components/CustomNavigationBarModifier.swift
+++ b/ABloom/ABloom/Resources/Components/CustomNavigationBarModifier.swift
@@ -38,7 +38,7 @@ struct CustomNavigationBarModifier<C, L, R>: ViewModifier where C: View, L: View
           
           self.centerView?()
             .fontWithTracking(.title3R)
-            .foregroundStyle(.stone700)
+            .foregroundStyle(.stone800)
           
           Spacer()
         }


### PR DESCRIPTION
#### related #83 

### ✏️ 개요
회원탈퇴 뷰 레이아웃을 구현합니다.

### 💻 작업 사항
네비게이션바 타이틀 색상을 .stone800으로 수정했습니다.
화면 이동과 기능을 제외하고 뷰를 구현했습니다.

### 📄 리뷰 노트
없습니다

### 📱결과 화면(optional)
<img src = "https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/100195563/51b71017-4599-45dc-a75a-b6fd80f478f1" width = "300"> 
