### PR TITLE
[Feat/#87] 상대방이 답변한 질문도 리스트에서 뜨지 않도록 수정

### DIFF
--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/QuestionMainView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/QuestionMainView.swift
@@ -38,11 +38,6 @@ struct QuestionMainView: View {
     .onAppear {
       questionVM.getInfo()
     }
-    
-    .task {
-      try? await questionVM.getUserSex()
-      try? await questionVM.getMyAnswers()
-    }
   }
 }
 

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/QuestionMainViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/QuestionMainViewModel.swift
@@ -69,6 +69,7 @@ final class QuestionMainViewModel: ObservableObject {
   func getInfo() {
     clearAll()
     Task {
+      try? await getUserSex()
       try? await getMyAnswers()
       try? await getFianceAnswers()
       distinctQuestions()
@@ -95,8 +96,8 @@ final class QuestionMainViewModel: ObservableObject {
   }
   
   private func clearAll() {
-    self.answers = []
-    self.questions = []
+    self.answers.removeAll()
+    self.questions.removeAll()
   }
   
   private func sortAnswers() {

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/SelectQuestionViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/SelectQuestionViewModel.swift
@@ -40,8 +40,8 @@ final class SelectQuestionViewModel: ObservableObject {
   }
   
   func fetchQuestions() async throws {
-    let userId = try AuthenticationManager.shared.getAuthenticatedUser().uid
-    self.questionLists = try await StaticQuestionManager.shared.getQuestionsWithoutAnswers(userId: userId)
+    let user = try await UserManager.shared.getCurrentUser()
+    self.questionLists = try await StaticQuestionManager.shared.getQuestionsWithoutAnswers(myId: user.userId, fianceId: user.fiance)
     filterQuestion()
   }
 }


### PR DESCRIPTION
#### close #87 

### ✏️ 개요
질문 선택하기 뷰에서 질문을 선택할 때, 상대방이 이미 작성한 질문도 가져오지 않도록 수정했습니다.

### 💻 작업 사항
- getQuestionsWithoutAnswers()메서드를 수정하였습니다.
- 자잘한 코드를 수정했습니다.

### 📄 리뷰 노트
결과 화면 참고.

### 📱결과 화면(optional)
<img width="511" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/77708819/32f703a6-fc2a-4a64-9d20-756a879fb9ff">
