### PR TITLE
[Bug/90] AnswerWrite Empty일 때, 처리

### DIFF
--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerWriteView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerWriteView.swift
@@ -48,10 +48,16 @@ struct AnswerWriteView: View {
         Text("문답 작성하기")
       },
       leftView: {
-        Button(action: answerVM.moveToBack, label: {
+        Button {
+          if answerVM.answerText == "" {
+            dismiss()
+          } else {
+            answerVM.setAlert()
+          }
+        } label: {
           Image("angle-left")
             .frame(width: 20, height: 20)
-        })
+        }
       },
       rightView: {
         Button {
@@ -62,6 +68,7 @@ struct AnswerWriteView: View {
             .fontWithTracking(.headlineR)
             .foregroundStyle(.stone700)
         }
+        .disabled(answerVM.answerText == "")
       })
     .background(backgroundDefault())
   }

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/AnswerWriteViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/AnswerWriteViewModel.swift
@@ -23,8 +23,7 @@ final class AnswerWriteViewModel: ObservableObject {
     self.sex = sex!
   }
   
-  
-  func moveToBack() {
+  func setAlert() {
     isAlertOn = true
   }
   


### PR DESCRIPTION
#### close #90

### ✏️ 개요
- AnswerWrite에서 작성한 텍스트가 없을 때, 처리

### 💻 작업 사항
- 벤틀리와 상의하여 Flow 적용
- 작성한 텍스트 없을 시, 
1. "완료" 버튼 비활성화
2. 뒤로 가기 버튼 클릭시 "삭제하시겠어요?" 얼럴트 창 나타나지 않고 dismiss

### 📄 리뷰 노트
질문을 fetch 하는 코드에서 task 처리를 규니가 하고 있어서, develop에서 에러가 발생했었습니다!
그래서 로직 구현만 하고 확인은 못해서 규니 코드 merge 후 다음 PR에서 이 부분도 같이 확인하겠습니다.

### 📱결과 화면(optional)
X 

### 📚 ETC(optional)
X