### PR TITLE
[Feat/#79] 연결코드 예외처리

### DIFF
--- a/ABloom/ABloom.xcodeproj/project.pbxproj
+++ b/ABloom/ABloom.xcodeproj/project.pbxproj
@@ -77,6 +77,8 @@
 		607DA20C2AEE5028005AE11C /* ImageFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607DA20B2AEE5028005AE11C /* ImageFileManager.swift */; };
 		607DA20E2AEF48AE005AE11C /* NavigationArrowLeft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607DA20D2AEF48AE005AE11C /* NavigationArrowLeft.swift */; };
 		607DA2122AEF5C96005AE11C /* DeleteAccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607DA2112AEF5C96005AE11C /* DeleteAccountView.swift */; };
+		607DA2142AEFCF93005AE11C /* ConnectionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607DA2132AEFCF93005AE11C /* ConnectionError.swift */; };
+		607DA2162AEFE900005AE11C /* ConnectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607DA2152AEFE900005AE11C /* ConnectionManager.swift */; };
 		AE1AE9F92AE50BBC0010089F /* QuestionMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1AE9F82AE50BBC0010089F /* QuestionMainView.swift */; };
 		AE1AE9FB2AE51BF00010089F /* QnAListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1AE9FA2AE51BF00010089F /* QnAListItem.swift */; };
 		AE1AE9FF2AE557E00010089F /* AnswerCheckView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1AE9FE2AE557E00010089F /* AnswerCheckView.swift */; };
@@ -148,6 +150,8 @@
 		607DA20B2AEE5028005AE11C /* ImageFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFileManager.swift; sourceTree = "<group>"; };
 		607DA20D2AEF48AE005AE11C /* NavigationArrowLeft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationArrowLeft.swift; sourceTree = "<group>"; };
 		607DA2112AEF5C96005AE11C /* DeleteAccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAccountView.swift; sourceTree = "<group>"; };
+		607DA2132AEFCF93005AE11C /* ConnectionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionError.swift; sourceTree = "<group>"; };
+		607DA2152AEFE900005AE11C /* ConnectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionManager.swift; sourceTree = "<group>"; };
 		AE1AE9F82AE50BBC0010089F /* QuestionMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionMainView.swift; sourceTree = "<group>"; };
 		AE1AE9FA2AE51BF00010089F /* QnAListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QnAListItem.swift; sourceTree = "<group>"; };
 		AE1AE9FE2AE557E00010089F /* AnswerCheckView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerCheckView.swift; sourceTree = "<group>"; };
@@ -221,6 +225,7 @@
 			children = (
 				3D4412422AE388DB00FD5A51 /* UserManager.swift */,
 				AEC260602AEA5A8000DF7CD5 /* StaticQuestionManager.swift */,
+				607DA2152AEFE900005AE11C /* ConnectionManager.swift */,
 			);
 			path = Firestore;
 			sourceTree = "<group>";
@@ -291,6 +296,7 @@
 			isa = PBXGroup;
 			children = (
 				3D4412772AE9F5E600FD5A51 /* ServiceWebURL.swift */,
+				607DA2132AEFCF93005AE11C /* ConnectionError.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -718,8 +724,10 @@
 				6053F15B2ADEB7700064A6E0 /* RegistrationViewModel.swift in Sources */,
 				3D4412582AE4F71000FD5A51 /* PolicyView.swift in Sources */,
 				3D957E902AEE7F4800D565E9 /* DBAnswerModel.swift in Sources */,
+				607DA2142AEFCF93005AE11C /* ConnectionError.swift in Sources */,
 				3D957E892AEE7ECF00D565E9 /* AnswerCheckViewModel.swift in Sources */,
 				6053F1712AE17A260064A6E0 /* HomeRecommendView.swift in Sources */,
+				607DA2162AEFE900005AE11C /* ConnectionManager.swift in Sources */,
 				6055411A2ADE66B000AD5625 /* RegistrationView.swift in Sources */,
 				AEAB19372ADF77210057BC43 /* Buttons.swift in Sources */,
 				605541152ADE1A9D00AD5625 /* TabBarView.swift in Sources */,

--- a/ABloom/ABloom/Firebase/Firestore/ConnectionManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/ConnectionManager.swift
@@ -1,0 +1,76 @@
+//
+//  ConnectionManager.swift
+//  ABloom
+//
+//  Created by Lee Jinhee on 10/30/23.
+//
+
+import FirebaseFirestore
+
+final class ConnectionManager {
+  static let shared = ConnectionManager()
+  @Published var isConnected: Bool = false
+  
+  private let userCollection = Firestore.firestore().collection("users")
+  
+  private func userDocument(userId: String) -> DocumentReference {
+    userCollection.document(userId)
+  }
+  
+  func fetchConnectionStatus() async throws {
+    if let currentUserFiance = try await getCurrentUser().fiance {
+      self.isConnected = !currentUserFiance.isEmpty
+    }
+  }
+  
+  private func getCurrentUser() async throws -> DBUser {
+    let currentUser = try AuthenticationManager.shared.getAuthenticatedUser()
+    return try await getUser(userId: currentUser.uid)
+  }
+  
+  private func getUser(userId: String) async throws -> DBUser {
+    try await userDocument(userId: userId).getDocument(as: DBUser.self)
+  }
+  
+  func connectFiance(connectionCode: String) async throws {
+    let snapshot = try await userCollection.whereField(DBUser.CodingKeys.invitationCode.rawValue, isEqualTo: connectionCode).getDocuments()
+    
+    /// 없는 코드에 접근한 경우
+    guard let target = snapshot.documents.first else {
+      throw ConnectionError.invalidConnectionCode
+    }
+    
+    let targetUser = try target.data(as: DBUser.self)
+    let targetUserId = targetUser.userId
+    let currentUser = try await getCurrentUser()
+    let currentUserId = currentUser.userId
+    
+    do {
+      /// 본인 아이디를 넣은 경우
+      if currentUser.invitationCode == targetUser.invitationCode {
+        throw ConnectionError.selfConnection
+      }
+      
+      /// 상대방이 이미 연결되어 있는 경우
+      if targetUser.fiance != nil {
+        throw ConnectionError.fianceAlreadyExists
+      }
+      
+      try await connectionUpdate(userId: currentUserId, targetId: targetUserId)
+      
+    } catch ConnectionError.fianceAlreadyExists {
+      throw ConnectionError.fianceAlreadyExists
+    } catch ConnectionError.invalidConnectionCode {
+      throw ConnectionError.invalidConnectionCode
+    } catch ConnectionError.selfConnection {
+      throw ConnectionError.selfConnection
+    }
+  }
+  
+  private func connectionUpdate(userId: String, targetId: String) async throws {
+    try await self.userDocument(userId: targetId).updateData([DBUser.CodingKeys.fiance.rawValue: userId])
+    try await self.userDocument(userId: userId).updateData([DBUser.CodingKeys.fiance.rawValue: targetId])
+    
+    self.isConnected = true
+  }
+}

--- a/ABloom/ABloom/Firebase/Firestore/UserManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/UserManager.swift
@@ -50,23 +50,6 @@ final class UserManager {
     userDocument(userId: userId).updateData(data)
   }
   
-  func connectFiance(connectionCode: String) async throws {
-    let snapshot = try await userCollection.whereField(DBUser.CodingKeys.invitationCode.rawValue, isEqualTo: connectionCode).getDocuments()
-    
-    guard let target = snapshot.documents.first else {
-      throw URLError(.badServerResponse)
-    }
-    
-    // TODO: 에러처리
-    // 1. 상대방이 이미 연결되어 있는 경우
-    // 2. 없는 코드에 접근한 경우
-    let targetId = try target.data(as: DBUser.self).userId
-    let myId = try AuthenticationManager.shared.getAuthenticatedUser().uid
-    
-    try await userDocument(userId: targetId).updateData([DBUser.CodingKeys.fiance.rawValue:myId])
-    try await userDocument(userId: myId).updateData([DBUser.CodingKeys.fiance.rawValue:targetId])
-  }
-  
   // MARK: Answer
   func creatAnswer(userId: String, questionId: Int, content: String) throws {
     let collection = userAnswerCollection(userId: userId)

--- a/ABloom/ABloom/Presentation/BoundaryViews/Connection/ConnectionView.swift
+++ b/ABloom/ABloom/Presentation/BoundaryViews/Connection/ConnectionView.swift
@@ -99,9 +99,12 @@ extension ConnectionView {
   
   private var connectButton: some View {
     Button(action: {
-      connectionVM.tryConnect()
-      if connectionVM.isConnectAble {
-        showLoginView = false
+      Task {
+        try? await connectionVM.tryConnect()
+        try? await connectionVM.getConnectionStatus()
+        if connectionVM.isConnected {
+          showLoginView = false
+        }
       }
     }, label: {
       if connectionVM.isTargetCodeInputVaild {
@@ -116,7 +119,7 @@ extension ConnectionView {
     .alert("연결에 실패했어요", isPresented: $connectionVM.showAlert, actions: {
       Button("확인") { }
     }, message: {
-      Text("상대방의 코드를 올바르게 입력했는지 확인해주세요.")
+      Text(connectionVM.errorMessage)
     })
   }
 }

--- a/ABloom/ABloom/Presentation/BoundaryViews/Connection/ConnectionViewModel.swift
+++ b/ABloom/ABloom/Presentation/BoundaryViews/Connection/ConnectionViewModel.swift
@@ -7,30 +7,54 @@
 
 import SwiftUI
 
+@MainActor
 final class ConnectionViewModel: ObservableObject {
 
   @Published var codeInputText: String = ""
   @Published var myCode: String?
-  @Published var isConnectAble: Bool = false
   @Published var showToast = false
   @Published var showAlert = false
-
-  // TODO: 연결시도가능, 유효가능 구분
+  @Published var errorMessage = ""
+  @Published var isConnected = false
+  /// 연결시도가능, 유효가능 구분
   var isTargetCodeInputVaild: Bool {
     !codeInputText.isEmpty
   }
   
-  // TODO: 연결 가능 확인 로직 수정
-  func tryConnect() {
-    self.isConnectAble = isTargetCodeInputVaild && codeInputText.count == 3
-    if !isConnectAble {
+  
+  func getMyCode() async throws {
+    let currentUser = try AuthenticationManager.shared.getAuthenticatedUser()
+    print("현재 유저 -> \(currentUser)")
+    self.myCode = try await UserManager.shared.getUser(userId: currentUser.uid).invitationCode
+  }
+  
+  func getConnectionStatus() async throws {
+    try await ConnectionManager.shared.fetchConnectionStatus()
+    self.isConnected = ConnectionManager.shared.isConnected
+  }
+  
+  func tryConnect() async throws {
+    if isTargetCodeInputVaild && codeInputText.count == 10 {
+      try await connect()
+    } else {
+      self.errorMessage = "상대방의 코드를 올바르게 입력했는지 확인해주세요."
       self.showAlert = true
     }
   }
   
-  func getMyCode() async throws {
-    let userId = try AuthenticationManager.shared.getAuthenticatedUser().uid
-    self.myCode = try await UserManager.shared.getUser(userId: userId).invitationCode
+  private func connect() async throws {
+    do {
+      try await ConnectionManager.shared.connectFiance(connectionCode: codeInputText)
+    } catch {
+      switch error {
+      case let connectionError as ConnectionError:
+        self.errorMessage = connectionError.errorMessage()
+        self.showAlert = true
+      default:
+        self.errorMessage = error.localizedDescription
+        self.showAlert = true
+      }
+    }
   }
   
   func copyClipboard() {

--- a/ABloom/ABloom/Presentation/CoreViews/Home/View/HomeView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Home/View/HomeView.swift
@@ -10,7 +10,8 @@ import SwiftUI
 
 struct HomeView: View {
   @StateObject var homeVM = HomeViewModel()
-  
+  @State var showLoginView = false
+
   var body: some View {
     VStack {
       Spacer().frame(maxHeight: 20)
@@ -33,9 +34,22 @@ struct HomeView: View {
     }
     .padding(.horizontal, 20)
     .background(backgroundDefault())
-    .task {
+  
+    .onAppear {
+      let authUser = try? AuthenticationManager.shared.getAuthenticatedUser()
+      self.showLoginView = authUser == nil
+      Task {
+        try? await homeVM.setInfo()
+      }
+    }
+    .task(id: showLoginView) {
       try? await homeVM.setInfo()
     }
+    .fullScreenCover(isPresented: $showLoginView, content: {
+      NavigationStack {
+        LoginView(showLoginView: $showLoginView)
+      }
+    })
   }
 }
 

--- a/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccountConnecting/MyAccountConnectingView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccountConnecting/MyAccountConnectingView.swift
@@ -103,7 +103,7 @@ extension MyAccountConnectingView {
     .alert("연결에 실패했어요", isPresented: $myAccountConnectingVM.showAlert, actions: {
       Button("확인") { }
     }, message: {
-      Text("상대방의 코드를 올바르게 입력했는지 확인해주세요.")
+      Text(myAccountConnectingVM.errorMessage)
     })
   }
 }

--- a/ABloom/ABloom/Presentation/CoreViews/TabBar/TabBarView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/TabBar/TabBarView.swift
@@ -43,16 +43,6 @@ struct TabBarView: View {
       }
       .ignoresSafeArea()
     }
-    
-    .onAppear {
-      let authUser = try? AuthenticationManager.shared.getAuthenticatedUser()
-      self.showLoginView = authUser == nil
-    }
-    .fullScreenCover(isPresented: $showLoginView, content: {
-      NavigationStack {
-        LoginView(showLoginView: $showLoginView)
-      }
-    })
   }
 }
 

--- a/ABloom/ABloom/Resources/Utilities/ConnectionError.swift
+++ b/ABloom/ABloom/Resources/Utilities/ConnectionError.swift
@@ -1,0 +1,24 @@
+//
+//  ConnectionError.swift
+//  ABloom
+//
+//  Created by Lee Jinhee on 10/30/23.
+//
+
+/// 사용자 정의 에러 타입
+enum ConnectionError: Error {
+  case fianceAlreadyExists
+  case invalidConnectionCode
+  case selfConnection
+  
+  func errorMessage() -> String {
+    switch self {
+    case .fianceAlreadyExists:
+      return "이미 연결된 상대방입니다."
+    case .invalidConnectionCode:
+      return "유효하지 않은 코드입니다."
+    case .selfConnection:
+      return "본인 아이디를 입력할 수 없습니다."
+    }
+  }
+}


### PR DESCRIPTION
#### related #79

### ✏️ 개요
연결코드 예외처리

### 💻 작업 사항
- [x] 로그인/회원가입 완료 시 정보 fetch되도록 수정
- [x] ConnectionError 추가
- [x] 연결 시 에러 상태에 따른 alert 메시지 변경
- [x] ConnectionManager 추가

### 📄 리뷰 노트
UserManager 부분이 길어져 ConnectionManager로 일단 분리했습니다 🤯
어렵네요.
저도 드디어 짝이 생겼어요.

### 📱결과 화면(optional)
<img src = "https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/100195563/d2648f2d-46f1-4803-a555-ad89531fa007" width = "300"> 
<img src = "https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/100195563/13131136-8bc9-4dc1-a2e8-10fdc1b13fbb" width = "300"> 

### 📚 ETC(optional)
제가 짝이 없어서 임의로 파베에서 유저를 만들어 작업을 했었는데요.
이놈이 uid를 자동생성을 해주는 걸로 했더니, 오류가 나더라구요.
uid 글자수가 기존에 생성했던 애들이랑 일치해야 비교가 되나봅니다 !
선생님들은 혹여나 그 언젠가 이 문제로 시간을 허비하지 마세요..