### PR TITLE
[Fix/#109] 질문 가져오기 로직 수정

### DIFF
--- a/ABloom/ABloom/Firebase/Firestore/StaticQuestionManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/StaticQuestionManager.swift
@@ -20,9 +20,18 @@ final class StaticQuestionManager {
       ids += try await getAnswersId(userId: fianceId)
     }
     
-    return try await  questionCollection
-      .whereField(DBStaticQuestion.CodingKeys.questionID.rawValue, notIn: ids.uniqued())
-      .getDocuments(as: DBStaticQuestion.self)
+    var allQuestions = try await questionCollection.getDocuments(as: DBStaticQuestion.self)
+    
+    allQuestions.removeAll { question in
+      for id in ids {
+        if id == question.questionID {
+          return true
+        }
+      }
+      return false
+    }
+    
+    return allQuestions
   }
   
   private func getAnswersId(userId: String) async throws -> [Int] {


### PR DESCRIPTION
#### close #109

### ✏️ 개요
질문 가져오기 시, 비교 쿼리 값으로 10개 이상 입력되면 쿼리가 동작하지 않는 현상을 발견했습니다.

### 💻 작업 사항
모든 질문을 가져온 뒤, 클라이언트 내부에서 필터링을 하는 방식으로 수정하였습니다.

### 📄 리뷰 노트
결과화면 참고

### 📱결과 화면(optional)
<img width="511" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/77708819/6c81e54b-0f96-4d30-868c-4a4c8ad3eae8">
