### PR TITLE
[Chore/111] ScrollView 수정, answers 빈 배열 수정(규니), 비었을 때 뷰 수정

### DIFF
--- a/ABloom/ABloom/Firebase/Firestore/StaticQuestionManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/StaticQuestionManager.swift
@@ -41,7 +41,10 @@ final class StaticQuestionManager {
   }
   
   func getAnsweredQuestions(questionIds: [Int]) async throws -> [DBStaticQuestion] {
-    try await questionCollection
+    if questionIds.isEmpty {
+      return []
+    }
+    return try await questionCollection
       .whereField(DBStaticQuestion.CodingKeys.questionID.rawValue, in: questionIds)
       .getDocuments(as: DBStaticQuestion.self)
   }

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerCheckView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerCheckView.swift
@@ -29,17 +29,17 @@ struct AnswerCheckView: View {
       Spacer()
         .frame(height: 10)
       
-      // 남성 일 경우
-      if sex {
-        malePart
-      } else { // 여성 일 경우
-        femalePart
+      if answerCheckVM.isDataOn == false {
+        ProgressView()
+      } else {
+        if sex { // 남성 일 경우
+          malePart
+        } else { // 여성 일 경우
+          femalePart
+        }
       }
     }
-    .onAppear {
-      answerCheckVM.getAnswers()
-    }
-    
+
     .customNavigationBar(
       centerView: {
         Text("우리의 문답")
@@ -54,7 +54,12 @@ struct AnswerCheckView: View {
       rightView: {
         EmptyView()
       })
+    
     .onAppear {
+      answerCheckVM.getAnswers()
+      
+      print(answerCheckVM.isDataOn)
+      
       if NavigationModel.shared.isPopToMain {
         NavigationModel.shared.popToMainToggle()
         dismiss()
@@ -83,8 +88,8 @@ extension AnswerCheckView {
           MyAccountConnectingView()
         } label: {
           LeftPinkChatBubble(text: "연결하기  >", isBold: true)
-            .padding(.leading, 40)
         }
+        .padding(.leading, 40)
         
         // if 내가 먼저 답하고, 상대방의 답변을 기다릴 경우
       } else if answerCheckVM.isNoFianceAnswer && !answerCheckVM.isNoMyAnswer {
@@ -132,8 +137,8 @@ extension AnswerCheckView {
           MyAccountConnectingView()
         } label: {
           LeftBlueChatBubble(text: "연결하기  >", isBold: true)
-            .padding(.leading, 40)
         }
+        .padding(.leading, 40)
         
         // if 내가 먼저 답하고, 상대방의 답변을 기다릴 경우
       } else if answerCheckVM.isNoFianceAnswer && !answerCheckVM.isNoMyAnswer {

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerCheckView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerCheckView.swift
@@ -83,6 +83,7 @@ extension AnswerCheckView {
           MyAccountConnectingView()
         } label: {
           LeftPinkChatBubble(text: "연결하기  >", isBold: true)
+            .padding(.leading, 40)
         }
         
         // if 내가 먼저 답하고, 상대방의 답변을 기다릴 경우
@@ -131,6 +132,7 @@ extension AnswerCheckView {
           MyAccountConnectingView()
         } label: {
           LeftBlueChatBubble(text: "연결하기  >", isBold: true)
+            .padding(.leading, 40)
         }
         
         // if 내가 먼저 답하고, 상대방의 답변을 기다릴 경우

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/QuestionMainView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/QuestionMainView.swift
@@ -17,7 +17,7 @@ struct QuestionMainView: View {
       Spacer()
         .frame(height: 34)
       
-      if questionVM.answers.isEmpty {
+      if questionVM.isEmpty {
         emptyListView
           .background(backWall())
         
@@ -35,7 +35,7 @@ struct QuestionMainView: View {
     })
     .background(backgroundDefault())
     
-    .onAppear {
+    .task {
       questionVM.getInfo()
     }
   }
@@ -59,13 +59,14 @@ extension QuestionMainView {
     .foregroundStyle(.stone700)
   }
   
+  // 질문 목록
   private var answeredQScroll: some View {
-    // 질문 목록
+    
     ScrollView(.vertical) {
+      Spacer()
+        .frame(height: 30)
+      
       LazyVStack(spacing: 30) {
-        
-        Spacer()
-          .frame(height: 0)
         
         ForEach(questionVM.questions, id: \.questionID) { question in
           NavigationLink(value: question.questionID) {
@@ -76,6 +77,9 @@ extension QuestionMainView {
               isAns: questionVM.checkAnswerStatus(qid: question.questionID))
           }
         }
+        // 탭 바로 가려지는 부분 뷰 처리
+        Spacer()
+          .frame(height: 20)
       }
     }
   }

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/QuestionMainView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/QuestionMainView.swift
@@ -21,9 +21,16 @@ struct QuestionMainView: View {
         emptyListView
           .background(backWall())
         
-      } else {
+      } else if questionVM.isSorted {
         answeredQScroll
           .background(backWall())
+      } else {
+        // Progress 현황확인
+        VStack {
+          ProgressView()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(backWall())
       }
     }
     .navigationDestination(for: Int.self, destination: { content in

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/AnswerCheckViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/AnswerCheckViewModel.swift
@@ -16,6 +16,7 @@ final class AnswerCheckViewModel: ObservableObject {
   @Published var isNoFiance = false
   @Published var isNoMyAnswer = false
   @Published var isNoFianceAnswer = false
+  @Published var isDataOn = false
   let questionId: Int
   
   let notConnectedText = "아직 상대방과 연결되어 있지 않아요. 지금 연결하고, 상대방의 문답을 확인해주세요."
@@ -29,6 +30,7 @@ final class AnswerCheckViewModel: ObservableObject {
   }
   
   func getAnswers() {
+    self.isDataOn = false
     // TODO: 상대방 응답
     Task {
       try? await getQuestion(by: self.questionId)
@@ -52,6 +54,7 @@ final class AnswerCheckViewModel: ObservableObject {
   private func getFianceAnswer() async throws {
     guard let fianceId = try await UserManager.shared.getCurrentUser().fiance else {
       self.isNoFiance = true
+      self.isDataOn = true
       throw URLError(.badServerResponse)
     }
     do {
@@ -59,6 +62,7 @@ final class AnswerCheckViewModel: ObservableObject {
       self.fianceAnswer = fianceAnswer.answerContent
       if let fianceName = try await UserManager.shared.getUser(userId: fianceId).name {
         self.fianceName = fianceName
+        self.isDataOn = true
       }
     } catch {
       self.isNoFianceAnswer = true

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/QuestionMainViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/QuestionMainViewModel.swift
@@ -78,6 +78,7 @@ final class QuestionMainViewModel: ObservableObject {
   @Published var questions: [DBStaticQuestion] = []
   @Published var sex = Bool()
   @Published var isEmpty = false
+  @Published var isSorted = false
   
   
   func getUserSex() async throws {
@@ -90,6 +91,7 @@ final class QuestionMainViewModel: ObservableObject {
   }
   
   func getInfo() {
+    self.isSorted = false
     clearAll()
     Task {
       try? await getUserSex()
@@ -137,7 +139,7 @@ final class QuestionMainViewModel: ObservableObject {
         }
       }
     }
-    
+    self.isSorted = true
     self.questions = newArray
   }
   

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/QuestionMainViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/QuestionMainViewModel.swift
@@ -37,14 +37,14 @@ enum Category: String, CaseIterable {
     case .future: return "미래"
     case .present: return "현재"
     case .past: return "과거"
-    
+      
     }
   }
   
   
   var imgName: String {
     switch self {
-    case .communication: 
+    case .communication:
       return "circleIcon_isometric_chatting"
     case .values:
       return "circleIcon_isometic_star"
@@ -77,6 +77,7 @@ final class QuestionMainViewModel: ObservableObject {
   @Published var answers: [DBAnswer] = []
   @Published var questions: [DBStaticQuestion] = []
   @Published var sex = Bool()
+  @Published var isEmpty = false
   
   
   func getUserSex() async throws {
@@ -150,6 +151,7 @@ final class QuestionMainViewModel: ObservableObject {
     let myAnswers = try await UserManager.shared.getAnswers(userId: userId)
     let questions = try await StaticQuestionManager.shared.getAnsweredQuestions(questionIds: myAnswers.map({ $0.questionId }))
     
+    self.isEmpty = myAnswers.isEmpty
     self.answers += myAnswers
     self.questions += questions
   }

--- a/ABloom/ABloom/Resources/Components/QnAListItem.swift
+++ b/ABloom/ABloom/Resources/Components/QnAListItem.swift
@@ -48,7 +48,8 @@ struct QnAListItem: View {
           
           Spacer()
         }
-        HStack {
+        
+        HStack(spacing: 0) {
           Text(formattedWeddingDate)
             .fontWithTracking(.caption2R)
           
@@ -67,7 +68,6 @@ struct QnAListItem: View {
         }
         .foregroundStyle(.stone500)
       }
-      Spacer()
     }
     .padding(.horizontal, 20)
   }


### PR DESCRIPTION
#### related #111

### ✏️ 개요
- 배포 전 버그 찾기 및 수정

### 💻 작업 사항
- 문답 탭에서 스크롤 버그 해결
- 새로 유저 생성 후 문답 탭 이동시 빈 배열로 인한 오류 해결 (규니)
- 배열이 비어있을 경우와 비어있지 않을 경우 우선 초기 스크린은 하얀 배경으로 설정
- 답변사항이 불러와 정렬 될 때, progressView로 대체
- AnswerWrite 뷰에 "연결하기" 버튼 패딩 값 조절

### 📄 리뷰 노트
계속해서 찾고 수정하겠습니다 :)

### 📱결과 화면(optional)
| Progress | Padding 조절 |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 Pro - 2023-10-31 at 12 20 28](https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/44897331/8981c64f-7ff1-41e5-aacd-ebeb948c9474) | ![Simulator Screenshot - iPhone 15 Pro - 2023-10-31 at 12 13 40](https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/44897331/ddde407e-2212-4016-814d-b11ddd81a329) | 

### 📚 ETC(optional)
X
