### PR TITLE
[Bug/#141] 카테고리 변경시 상단으로 스크롤

### DIFF
--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/SelectQuestionView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/SelectQuestionView.swift
@@ -115,7 +115,7 @@ extension SelectQuestionView {
       ScrollViewReader { proxy in
         ScrollView(.vertical) {
           Spacer()
-            .frame(height: 0)
+            .frame(height: 16)
             .id("top")
           
           ForEach(selectQVM.filteredLists, id: \.self) { question in
@@ -130,7 +130,6 @@ extension SelectQuestionView {
             .padding(.vertical, 7)
           }
         }
-        .padding(.top, 16)
         .padding(.bottom, 50)
         
         .onChange(of: selectQVM.selectedCategory) { new in

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/SelectQuestionView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/SelectQuestionView.swift
@@ -128,13 +128,17 @@ extension SelectQuestionView {
             }
             .padding(.horizontal, 20)
             .padding(.vertical, 7)
+            
+            if selectQVM.filteredLists.last == question {
+              Spacer()
+                .frame(height: 50)
+            }
           }
         }
-        .padding(.bottom, 50)
-        
         .onChange(of: selectQVM.selectedCategory) { new in
           proxy.scrollTo("top")
         }
+      
       }
     }
   }

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/SelectQuestionView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/SelectQuestionView.swift
@@ -19,15 +19,18 @@ struct SelectQuestionView: View {
       categoryBar
       
       if selectQVM.isReady {
+        
         questionListView
-         
           .background(backWall())
+        
       } else {
+        
         VStack {
           ProgressView()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(backWall())
+        
       }
     }
     .navigationDestination(for: DBStaticQuestion.self, destination: { content in
@@ -40,11 +43,10 @@ struct SelectQuestionView: View {
         dismiss()
       }
     }
-  
+    
     .task {
       try? await selectQVM.fetchQuestions()
     }
-    
     
     // 네비게이션바
     .customNavigationBar(
@@ -98,7 +100,7 @@ extension SelectQuestionView {
   
   private var questionListView: some View {
     VStack(spacing: 0) {
-
+      
       HStack {
         Text("\(selectQVM.selectedCategory.type) 문답")
           .fontWithTracking(.headlineR)
@@ -108,19 +110,31 @@ extension SelectQuestionView {
       }
       .padding(.horizontal, 22)
       .padding(.top, 34)
-      .padding(.bottom, 26)
+      .padding(.bottom, 10)
       
-      ScrollView(.vertical) {
-        ForEach(selectQVM.filteredLists, id: \.self) { question in
-          NavigationLink(value: question) {
-            if sex {
-              LeftPinkChatBubble(text: question.content)
-            } else {
-              LeftBlueChatBubble(text: question.content)
+      ScrollViewReader { proxy in
+        ScrollView(.vertical) {
+          Spacer()
+            .frame(height: 0)
+            .id("top")
+          
+          ForEach(selectQVM.filteredLists, id: \.self) { question in
+            NavigationLink(value: question) {
+              if sex {
+                LeftPinkChatBubble(text: question.content)
+              } else {
+                LeftBlueChatBubble(text: question.content)
+              }
             }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 7)
           }
-          .padding(.horizontal, 20)
-          .padding(.bottom, 12)
+        }
+        .padding(.top, 16)
+        .padding(.bottom, 50)
+        
+        .onChange(of: selectQVM.selectedCategory) { new in
+          proxy.scrollTo("top")
         }
       }
     }


### PR DESCRIPTION
#### close #141

### ✏️ 개요
- 질문선택뷰에서 카테고리 변경 시 스크롤이 유지되는 현상 해결

### 💻 작업 사항
- ScrollViewReader 도입으로 카테고리가 변경될 경우, 상단으로 이동하도록 해결
- padding 값 피그마 보고 눈대중으로 재조정
- bottom 부분에 패딩 추가하여 사용성 부분 개선

### 📄 리뷰 노트
1. onChange에 new 값을 안 적으면, 17버전에서만 사용되는 함수라고 되어서, 안쓰는 변수이지만 기존 onChange 함수에서 쓰는 것처럼 추가해 두었습니다.
2. forEach 문 내부에서는 VStack(spacing) 값이 통하지 않아 일일히 패딩 적용하였습니다.
3. top 패딩 대신 가장 상단의 Spacer 부분의 값을 조정하였습니다.
4. 카테고리 제목이 차지하는 뷰가 많아서 스크롤시 조금 줄였습니다.

### 📱결과 화면(optional)

![Simulator Screenshot - iPhone 15 Pro - 2023-11-04 at 17 52 24](https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/44897331/d458000a-5b78-43fe-8507-16c3cdd234d5)


### 📚 ETC(optional)
X
