### PR TITLE
[Feat/#135] 홈뷰 레이아웃 수정, 상대방 성별 불러오기

### DIFF
--- a/ABloom/ABloom/Presentation/CoreViews/Home/View/HomeRecommendView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Home/View/HomeRecommendView.swift
@@ -24,15 +24,16 @@ struct HomeRecommendView: View {
           .fontWithTracking(.subHeadlineBold)
           .foregroundStyle(.stone800)
         
-        Text("\(recommendQuestion)")
-          .lineLimit(2)
-          .truncationMode(.tail)
-          .foregroundStyle(.stone600)
-          .multilineTextAlignment(.leading)
-          .fontWithTracking(.footnoteR, tracking: -0.4, lineSpacing: 2)
+        HStack {
+          Text("\(recommendQuestion)")
+            .lineLimit(2)
+            .truncationMode(.tail)
+            .foregroundStyle(.stone600)
+            .multilineTextAlignment(.leading)
+            .fontWithTracking(.footnoteR, tracking: -0.4, lineSpacing: 2)
+          Spacer()
+        }
       }
-      
-      Spacer()
     }
     .padding(.horizontal, 24)
     .background(

--- a/ABloom/ABloom/Presentation/CoreViews/Home/View/HomeView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Home/View/HomeView.swift
@@ -145,6 +145,7 @@ extension HomeView {
           cameraButton
         }
       }
+      .zIndex(-1)
   }
   
   private var defaultImage: some View {

--- a/ABloom/ABloom/Presentation/CoreViews/Home/View/HomeView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Home/View/HomeView.swift
@@ -46,22 +46,23 @@ struct HomeView: View {
     }
     .background(backgroundDefault())
     
-    .onAppear {
+    .task {
       let authUser = try? AuthenticationManager.shared.getAuthenticatedUser()
       homeVM.showLoginView = authUser == nil
-    }
-    
-    .task(id: homeVM.showLoginView) {
+
       if homeVM.showLoginView == false {
         try? await homeVM.setInfo()
       }
     }
-  
-    .fullScreenCover(isPresented: $homeVM.showLoginView, content: {
+
+    .fullScreenCover(isPresented: $homeVM.showLoginView) {
       NavigationStack {
         LoginView(showLoginView: $homeVM.showLoginView)
       }
-    })
+      .onDisappear {
+        Task { try? await homeVM.setInfo() }
+      }
+    }
   }
 }
 

--- a/ABloom/ABloom/Presentation/CoreViews/Home/View/HomeView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Home/View/HomeView.swift
@@ -10,54 +10,56 @@ import SwiftUI
 
 struct HomeView: View {
   @StateObject var homeVM = HomeViewModel()
-  @State var showLoginView = false
   private let hPadding = 20.0
 
   var body: some View {
-    VStack {
+    VStack(spacing: 0) {
+      Spacer().frame(height: 4)
+      
       if homeVM.isReady {
-        
-        Spacer().frame(maxHeight: 20)
-        
-        titleArea
-        
-        Spacer().frame(maxHeight: 32)
-        
-        if homeVM.savedImage == nil {
-          defaultImage
-        } else {
-          savedImage
+        ScrollView(showsIndicators: false) {
+          Spacer().frame(height: 16)
+          
+          titleArea
+            .padding(.horizontal, hPadding)
+          
+          Spacer().frame(height: 32)
+          
+          if homeVM.savedImage == nil {
+            defaultImage
+          } else {
+            savedImage
+          }
+          
+          Spacer().frame(height: 40)
+          
+          recommendArea
+            .padding(.horizontal, hPadding)
+          
+          Spacer().frame(minHeight: 60)
         }
         
-        Spacer().frame(maxHeight: 40)
-        
-        recommendArea
-        
-        Spacer()
       } else {
         ProgressView()
           .frame(maxWidth: .infinity, maxHeight: .infinity)
       }
     }
-    .padding(.horizontal, 20)
     .background(backgroundDefault())
-  
+    
     .onAppear {
       let authUser = try? AuthenticationManager.shared.getAuthenticatedUser()
-      self.showLoginView = authUser == nil
-
-      Task {
+      homeVM.showLoginView = authUser == nil
+    }
+    
+    .task(id: homeVM.showLoginView) {
+      if homeVM.showLoginView == false {
         try? await homeVM.setInfo()
       }
     }
-    
-    .task(id: showLoginView) {
-      try? await homeVM.setInfo()
-    }
-    
-    .fullScreenCover(isPresented: $showLoginView, content: {
+  
+    .fullScreenCover(isPresented: $homeVM.showLoginView, content: {
       NavigationStack {
-        LoginView(showLoginView: $showLoginView)
+        LoginView(showLoginView: $homeVM.showLoginView)
       }
     })
   }

--- a/ABloom/ABloom/Presentation/CoreViews/Home/View/HomeView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Home/View/HomeView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct HomeView: View {
   @StateObject var homeVM = HomeViewModel()
   @State var showLoginView = false
+  private let hPadding = 20.0
 
   var body: some View {
     VStack {
@@ -129,7 +130,8 @@ extension HomeView {
     Image(uiImage: homeVM.savedImage!)
       .resizable()
       .scaledToFill()
-      .frame(maxHeight: 387)
+      .frame(width: UIScreen.main.bounds.width - CGFloat(2 * hPadding))
+      .frame(minHeight: 350, maxHeight: 380)
       .overlay {
         Color.biPink.opacity(0.2)
       }
@@ -145,8 +147,8 @@ extension HomeView {
   private var defaultImage: some View {
     Image(uiImage: homeVM.defaultImage)
       .resizable()
-      .scaledToFit()
-      .frame(maxHeight: 387)
+      .scaledToFill()
+      .frame(width: UIScreen.main.bounds.width - CGFloat(2 * hPadding), height: 380)
       .clipShape(RoundedRectangle(cornerRadius: 28))
       .shadow(color: Color.purple200, radius: 20, x: 0, y: 20)
       .overlay(alignment: .topTrailing) {

--- a/ABloom/ABloom/Presentation/CoreViews/Home/View/HomeView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Home/View/HomeView.swift
@@ -11,7 +11,8 @@ import SwiftUI
 struct HomeView: View {
   @StateObject var homeVM = HomeViewModel()
   private let hPadding = 20.0
-
+  private let imageSize = UIScreen.main.bounds.width - CGFloat(40.0)
+  
   var body: some View {
     VStack(spacing: 0) {
       Spacer().frame(height: 4)
@@ -27,8 +28,10 @@ struct HomeView: View {
           
           if homeVM.savedImage == nil {
             defaultImage
+              .padding(.horizontal, hPadding)
           } else {
             savedImage
+              .padding(.horizontal, hPadding)
           }
           
           Spacer().frame(height: 40)
@@ -133,8 +136,7 @@ extension HomeView {
     Image(uiImage: homeVM.savedImage!)
       .resizable()
       .scaledToFill()
-      .frame(width: UIScreen.main.bounds.width - CGFloat(2 * hPadding))
-      .frame(minHeight: 350, maxHeight: 380)
+      .frame(width: imageSize, height: imageSize)
       .overlay {
         Color.biPink.opacity(0.2)
       }
@@ -152,7 +154,7 @@ extension HomeView {
     Image(uiImage: homeVM.defaultImage)
       .resizable()
       .scaledToFill()
-      .frame(width: UIScreen.main.bounds.width - CGFloat(2 * hPadding), height: 380)
+      .frame(width: imageSize, height: imageSize)
       .clipShape(RoundedRectangle(cornerRadius: 28))
       .shadow(color: Color.purple200, radius: 20, x: 0, y: 20)
       .overlay(alignment: .topTrailing) {

--- a/ABloom/ABloom/Presentation/CoreViews/Home/ViewModel/HomeViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Home/ViewModel/HomeViewModel.swift
@@ -85,9 +85,9 @@ final class HomeViewModel: ObservableObject {
     }
     
     try getMarrigeDate(user: dbUser)
-    self.isReady = true
-        
     try await loadRecommendQuestion(user: dbUser)
+    
+    self.isReady = true
   }
   
   private func getFianceSex(user: DBUser) throws {

--- a/ABloom/ABloom/Presentation/CoreViews/Home/ViewModel/HomeViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Home/ViewModel/HomeViewModel.swift
@@ -75,19 +75,17 @@ final class HomeViewModel: ObservableObject {
     let dbUser = try await UserManager.shared.getCurrentUser()
     
     self.isConnected = dbUser.fiance != nil
+    try getFianceSex(user: dbUser)
     
     if self.isConnected == true {
       try await getFiance(user: dbUser)
-      try getFianceSex(user: dbUser)
       try await getQnACount(user: dbUser)
     }
     
     try getMarrigeDate(user: dbUser)
     self.isReady = true
         
-    // TODO: 라딘~ 이 함수에 문제가 있는지, 이 함수 이후에 정의한 함수에 접근하지 않습니다. 그래서 일단 맨 뒤로 옮겼어요.
     try await loadRecommendQuestion(user: dbUser)
-    
   }
   
   private func getFianceSex(user: DBUser) throws {

--- a/ABloom/ABloom/Presentation/CoreViews/Home/ViewModel/HomeViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Home/ViewModel/HomeViewModel.swift
@@ -17,6 +17,8 @@ final class HomeViewModel: ObservableObject {
   @Published var isConnected: Bool = false
   @Published var isConnectButtonTapped = false
   
+  @Published var showLoginView = false
+  
   @Published var showDialog = false
   @Published var showPhotosPicker = false
   @Published var isReady = false


### PR DESCRIPTION
#### related #135

### ✏️ 개요
홈뷰 레이아웃과 버그를 수정하였습니다.
HomeView Appear시 실행되는 중복 태스크를 일부 수정하였습니다.


### 💻 작업 사항
- [x] 홈뷰 스크롤 적용
- [x] 홈뷰 사진 크기 수정(가로로 긴사진도 잘리지 않도록)
- [x] 홈뷰 미연결 시 상대방 성별 불러오기
- [x] 홈뷰 태스크 수정

### 📄 리뷰 노트
홈뷰 사진의 경우 높이를 380으로 고정해두면 SE에서 길어져 최소최대값을 주는 방식으로 적용하였습니다.

기존에 onAppear과 task로 분리되어있던 부분을 task로 변경하고,
.task(id: showLoginView) {}을 Sheet가 사라질 경우 실행되도록 수정하였습니다.

### 📱결과 화면(optional)
![Simulator Screen Recording - iPhone 15 Plus - 2023-11-04 at 17 52 47](https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/100195563/af9ad32a-1e7b-4bf2-a19a-39b90ff59d8e)
