### PR TITLE
[Bug/#144] SelectQuestionView 질문 오름차순 정렬

### DIFF
--- a/ABloom/ABloom/Firebase/Firestore/StaticQuestionManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/StaticQuestionManager.swift
@@ -24,7 +24,7 @@ final class StaticQuestionManager {
       ids += try await getAnswersId(userId: fianceId)
     }
     
-    var allQuestions = try await questionCollection.getDocuments(as: DBStaticQuestion.self)
+    var allQuestions = try await questionCollection.order(by: "q_id").getDocuments(as: DBStaticQuestion.self)
     
     allQuestions.removeAll { question in
       for id in ids {

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/SelectQuestionViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/SelectQuestionViewModel.swift
@@ -27,6 +27,9 @@ final class SelectQuestionViewModel: ObservableObject {
         filteredLists.append(question)
       }
     }
+    filteredLists.sort {
+      $0.questionID < $1.questionID
+    }
   }
   
   func fetchQuestions() async throws {

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/SelectQuestionViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/SelectQuestionViewModel.swift
@@ -27,9 +27,6 @@ final class SelectQuestionViewModel: ObservableObject {
         filteredLists.append(question)
       }
     }
-    filteredLists.sort {
-      $0.questionID < $1.questionID
-    }
   }
   
   func fetchQuestions() async throws {


### PR DESCRIPTION
#### related #144

### ✏️ 개요
질문선택뷰의 질문이 qid에 따라 정렬되지 않아 있던 부분을 수정하였습니다.

### 💻 작업 사항
질문선택뷰의 질문을 오름차순으로 정렬하였습니다.

### 📄 리뷰 노트
원본배열을 정렬하기 위해 sort를 사용하였습니다

### 📱결과 화면(optional)
<img src = "https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/100195563/0eadd97d-4dc4-4cdc-8643-984fc8db2109" width = "300"> 
