### PR TITLE
[Feat/#147] 상대방과 연결 뷰에서 나의 코드를 볼 수 있도록 수정하였습니다.

### DIFF
--- a/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccountConnecting/ConnectedView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccountConnecting/ConnectedView.swift
@@ -25,6 +25,8 @@ struct ConnectedView: View {
           .frame(width: imageSize, height: imageSize)
         
         Text("\(fianceName)님과 연결되어 있습니다.")
+          .fontWithTracking(.bodyR)
+          .foregroundStyle(.stone800)
       }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccountConnecting/ConnectedView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccountConnecting/ConnectedView.swift
@@ -26,6 +26,7 @@ struct ConnectedView: View {
           .resizable()
           .scaledToFill()
           .frame(width: imageSize, height: imageSize)
+          .padding(.top, 50)
           .padding(.bottom, 10)
         
         Text("\(fianceName)님과 연결되어 있습니다.")
@@ -35,6 +36,14 @@ struct ConnectedView: View {
         
         myCodeBox
           .padding(.horizontal, 20)
+        
+        Spacer()
+        
+        if showToast {
+          ToastView(message: "코드가 복사되었습니다")
+        }
+        
+        Spacer()
       }
       
     }

--- a/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccountConnecting/ConnectedView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccountConnecting/ConnectedView.swift
@@ -57,7 +57,7 @@ struct ConnectedView: View {
     }
     
     .customNavigationBar {
-      Text("상대방과 연결")
+      Text("연결 설정")
     } leftView: {
       Button {
         dismiss()

--- a/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccountConnecting/ConnectedView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccountConnecting/ConnectedView.swift
@@ -9,33 +9,44 @@ import SwiftUI
 
 struct ConnectedView: View {
   @Environment(\.dismiss) private var dismiss
-
   @State var fianceName: String = ""
+  @State var showToast = false
   
   let fianceId: String
+  let myCode: String
   let imageSize: CGFloat = 206
   
   var body: some View {
-    VStack {
+    VStack(spacing: 0) {
+      
       if fianceName == "" {
         ProgressView()
       } else {
         Image("check")
           .resizable()
+          .scaledToFill()
           .frame(width: imageSize, height: imageSize)
+          .padding(.bottom, 10)
         
         Text("\(fianceName)님과 연결되어 있습니다.")
-          .fontWithTracking(.bodyR)
+          .fontWithTracking(.bodyR, tracking: -0.4)
           .foregroundStyle(.stone800)
+          .padding(.bottom, 50)
+        
+        myCodeBox
+          .padding(.horizontal, 20)
       }
+      
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
+    
     .task {
       guard let fianceName = try? await UserManager.shared.getUser(userId: fianceId).name
       else { return }
       
       self.fianceName = fianceName
     }
+    
     .customNavigationBar {
       Text("상대방과 연결")
     } leftView: {
@@ -47,12 +58,38 @@ struct ConnectedView: View {
     } rightView: {
       EmptyView()
     }
+    
     .background(backgroundDefault())
   }
+  
 }
 
 #Preview {
   NavigationStack {
-    ConnectedView(fianceId: "")
+    ConnectedView(fianceId: "", myCode: "")
+  }
+}
+
+extension ConnectedView {
+  private var myCodeBox: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text("나의 연결 코드")
+        .fontWithTracking(.subHeadlineR)
+      
+      CopyStrokeInputField(myCode: myCode, copyAction: copyClipboard)
+    }
+  }
+  
+  private func copyClipboard() {
+    UIPasteboard.general.string = myCode
+    withAnimation {
+      showToast.toggle()
+    }
+    
+    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+      withAnimation {
+        self.showToast = false
+      }
+    }
   }
 }

--- a/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccountConnecting/ConnectionWaypointView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccountConnecting/ConnectionWaypointView.swift
@@ -13,8 +13,10 @@ struct ConnectionWaypointView: View {
   var body: some View {
     VStack {
       if waypointVM.isReady {
-        if let fianceId = waypointVM.currentUser?.fiance {
-          ConnectedView(fianceId: fianceId)
+        if let fianceId = waypointVM.currentUser?.fiance,
+           let myCode = waypointVM.currentUser?.invitationCode
+        {
+          ConnectedView(fianceId: fianceId, myCode: myCode)
         } else {
           MyAccountConnectingView()
         }

--- a/ABloom/ABloom/Resources/Components/InputFields.swift
+++ b/ABloom/ABloom/Resources/Components/InputFields.swift
@@ -7,18 +7,20 @@
 
 import SwiftUI
 
-///연결 코드 복사 뷰
+/// 연결 코드 복사 뷰
 struct CopyStrokeInputField: View {
   let myCode: String?
   var copyAction: () -> Void
 
   var body: some View {
     HStack {
-      Image(systemName: "clipboard")
+      Image(systemName: "clipboard.fill")
         .font(.calloutR)
+        .foregroundStyle(.stone900)
      
       Text(myCode ?? "코드를 불러오지 못했습니다")
         .fontWithTracking(.calloutBold, tracking: -0.4)
+        .foregroundStyle(.stone900)
       
       Spacer()
       
@@ -33,7 +35,7 @@ struct CopyStrokeInputField: View {
   }
 }
 
-///연결 코드 입력 뷰
+/// 연결 코드 입력 뷰
 struct ConnectCodeStrokeInputField: View {
   @Binding var codeInputText: String
   let isTargetCodeValid: Bool

--- a/ABloom/ABloom/Resources/Utilities/ServiceWebURL.swift
+++ b/ABloom/ABloom/Resources/Utilities/ServiceWebURL.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 enum ServiceWebURL: String {
-  case questionLab = "https://smore.im/form/GCmzTMTiGQ"
-  case qna = "https://smore.im/form/pgvrm4mEbf"
+  case questionLab = "https://bit.ly/3FKGoKB"
+  case qna = "https://bit.ly/3Sq7A8S"
   case termsOfuse = "https://jaeseoklee.notion.site/9a4458152dd045ca82f8010fb46c5776"
   case privacyPolicy = "https://jaeseoklee.notion.site/Mery-78953ca6310b40209cb993312bbf9339?pvs=4"
 }


### PR DESCRIPTION
#### close #147

### ✏️ 개요
상대방과 연결 뷰에서 나의 코드를 볼 수 있도록 수정하였습니다.

### 💻 작업 사항
- 연결 상태 메세지 폰트 수정
- 연결 코드 박스 컴포넌트 디자인 수정
- 연결 코드 박스 뷰 추가
- 레이아웃 수정

### 📄 리뷰 노트
- 너무 기능이 심플한 것 같아서, 따로 ViewModel을 정의하지 않고 뷰에서 기능들을 구현하였습니다. 필요하다면 뷰모델을 구현하도록 하겠습니다.
- 기능 테스트를 위해 임의로 배찌와 연결하고, 삭제하였습니다.

### 📱결과 화면(optional)
|연결 완료 뷰|복사 시 토스트메세지|
|---|---|
|<img width="511" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/77708819/d4c63a42-6b0f-4396-b582-7e7cfec7413d">|<img width="511" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/77708819/c01d1eab-eca0-4d05-ad6c-ed44f7d5cd78">|
