### PR TITLE
[Bug/#131] 추천질문 변경 날짜 한국시간으로 수정

### DIFF
--- a/ABloom/ABloom/Resources/Extensions/Ex+Date.swift
+++ b/ABloom/ABloom/Resources/Extensions/Ex+Date.swift
@@ -8,11 +8,21 @@
 import Foundation
 
 extension Date: RawRepresentable {
-    public var rawValue: String {
-        self.timeIntervalSinceReferenceDate.description
-    }
+  public var rawValue: String {
+    self.timeIntervalSinceReferenceDate.description
+  }
+  
+  public init?(rawValue: String) {
+    self = Date(timeIntervalSinceReferenceDate: Double(rawValue) ?? 0.0)
+  }
+  
+  public func isSameDate(lastChangedDate: Date) -> Bool {
+    var calendar = Calendar.current
+    calendar.timeZone = TimeZone(identifier: "Asia/Seoul")!
     
-    public init?(rawValue: String) {
-        self = Date(timeIntervalSinceReferenceDate: Double(rawValue) ?? 0.0)
-    }
+    let selfComponents = calendar.dateComponents([.year, .month, .day], from: self)
+    let lastChangedDateComponents = calendar.dateComponents([.year, .month, .day], from: lastChangedDate)
+    
+    return selfComponents == lastChangedDateComponents
+  }
 }


### PR DESCRIPTION
#### close #131 

### ✏️ 개요
추천질문 업데이트 날과 현재 날을 비교하고 저장하는 부분이 한 번 꼬여있어, 3시에 변경되는 걸로 계산되어 있던 부분을 수정하였습니다.

### 💻 작업 사항
- [x] 추천질문 날짜 로직 변경

### 📄 리뷰 노트
지난 업데이트날짜와 현재 날짜를 UTC +0으로 두고, 
같은 날인지 확인하는 부분에서 UTC +9 (아시아/서울) 시간대로 변경하여 비교하도록 수정하였습니다.