### PR TITLE
[Feat/#159] 로컬 푸쉬 기능 구현, 내용은 미확정

### DIFF
--- a/ABloom/ABloom.xcodeproj/project.pbxproj
+++ b/ABloom/ABloom.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		AEB502642AE5FA840056E439 /* CustomNavigationBarModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB502632AE5FA840056E439 /* CustomNavigationBarModifier.swift */; };
 		AEB5026B2AE64B8D0056E439 /* CategoryQuestionBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB5026A2AE64B8D0056E439 /* CategoryQuestionBox.swift */; };
 		AEC260612AEA5A8000DF7CD5 /* StaticQuestionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC260602AEA5A8000DF7CD5 /* StaticQuestionManager.swift */; };
+		AEE9EC762AF7C6350026D803 /* LocalPushNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE9EC752AF7C6350026D803 /* LocalPushNotification.swift */; };
 		AEEA8DCF2AEB82070068550E /* SelectQuestionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEA8DCE2AEB82070068550E /* SelectQuestionViewModel.swift */; };
 		AEEA8DD12AEB82290068550E /* SelectQuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEA8DD02AEB82290068550E /* SelectQuestionView.swift */; };
 		AEEA8DD32AEB82520068550E /* ChatBubbles.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEA8DD22AEB82520068550E /* ChatBubbles.swift */; };
@@ -189,6 +190,7 @@
 		AEB502632AE5FA840056E439 /* CustomNavigationBarModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNavigationBarModifier.swift; sourceTree = "<group>"; };
 		AEB5026A2AE64B8D0056E439 /* CategoryQuestionBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryQuestionBox.swift; sourceTree = "<group>"; };
 		AEC260602AEA5A8000DF7CD5 /* StaticQuestionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticQuestionManager.swift; sourceTree = "<group>"; };
+		AEE9EC752AF7C6350026D803 /* LocalPushNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalPushNotification.swift; sourceTree = "<group>"; };
 		AEEA8DCE2AEB82070068550E /* SelectQuestionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectQuestionViewModel.swift; sourceTree = "<group>"; };
 		AEEA8DD02AEB82290068550E /* SelectQuestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectQuestionView.swift; sourceTree = "<group>"; };
 		AEEA8DD22AEB82520068550E /* ChatBubbles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatBubbles.swift; sourceTree = "<group>"; };
@@ -506,6 +508,7 @@
 				3D4412792AEAB34000FD5A51 /* GoogleService-Info.plist */,
 				AE7EE4E02AD6409000E0A573 /* ABloomApp.swift */,
 				AE5EB9FA2AF1396C0074F361 /* AppDelegate.swift */,
+				AEE9EC752AF7C6350026D803 /* LocalPushNotification.swift */,
 				AEB502652AE61AD70056E439 /* Resources */,
 				6053F1632ADF7F3D0064A6E0 /* Presentation */,
 				3DB6A5AC2AE0C0B700C1369F /* Firebase */,
@@ -732,6 +735,7 @@
 				3D957E9C2AEF998000D565E9 /* Ex+Sequence.swift in Sources */,
 				6053F1762AE899320064A6E0 /* InputFields.swift in Sources */,
 				6086BAA92AF130A800E2DC3A /* DBEssentialQuestionModel.swift in Sources */,
+				AEE9EC762AF7C6350026D803 /* LocalPushNotification.swift in Sources */,
 				AE1AE9FB2AE51BF00010089F /* QnAListItem.swift in Sources */,
 				AE8D3C512ADE19E0009899A7 /* Ex+Font.swift in Sources */,
 				607DA2182AF0B07D005AE11C /* Ex+Date.swift in Sources */,
@@ -937,6 +941,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = "Launch Screen.storyboard";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -981,6 +986,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = "Launch Screen.storyboard";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ABloom/ABloom/ABloomApp.swift
+++ b/ABloom/ABloom/ABloomApp.swift
@@ -6,15 +6,19 @@
 //
 import Firebase
 import SwiftUI
+import UserNotifications
 
 
 @main
 struct ABloomApp: App {
-  // TODO: Notificaiton을 위한 자료 -> Sprint2 진행
-  // @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+  // TODO: Notificaiton을 위한 자료
+  //   @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
   
   init() {
     FirebaseApp.configure()
+    // TODO: Local + Firebase 합치기
+    requestNotificationPermission()
+    
     print("Firebase configured!")
   }
   

--- a/ABloom/ABloom/Info.plist
+++ b/ABloom/ABloom/Info.plist
@@ -5,7 +5,8 @@
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSUserNotificationsUsageDescription</key>
-	<string>예랑이/예신이의 실시간 답변을 확인하고 매일 추천질문을 받을 수 있도록 알림을 허용합니다.</string>
+	<string>'메리'에서 알림을 보내고자 합니다.
+경고, 사운드 및 아이콘 배지가 알림에 포함될 수 있습니다. 설정에서 이를 구성할 수 있습니다.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>SpoqaHanSansNeo-Thin.ttf</string>

--- a/ABloom/ABloom/Info.plist
+++ b/ABloom/ABloom/Info.plist
@@ -2,10 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIUserInterfaceStyle</key>
-	<string>Light</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>NSUserNotificationsUsageDescription</key>
+	<string>예랑이/예신이의 실시간 답변을 확인하고 매일 추천질문을 받을 수 있도록 알림을 허용합니다.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>SpoqaHanSansNeo-Thin.ttf</string>

--- a/ABloom/ABloom/LocalPushNotification.swift
+++ b/ABloom/ABloom/LocalPushNotification.swift
@@ -1,0 +1,49 @@
+//
+//  LocalPushNotification.swift
+//  ABloom
+//
+//  Created by yun on 11/5/23.
+//
+
+import UserNotifications
+
+// MARK: AppDelegate 파일에서 Firebase쪽 통신과 함께 다뤄야 하는데, Ref을 진행하여서 일단 파일하나에 관련 함수 정리해두었습니다.
+
+
+func requestNotificationPermission() {
+  UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+    
+    // 변수를 설정에서 셋팅한다면, 변수로 확인해서 데일리 알림을 온/오프 할 수 있을 듯
+    
+    if granted {
+      scheduleDailyNotification()
+      print("granted")
+    } else {
+      // Handle the case where permission was denied
+    }
+  }
+}
+
+func scheduleDailyNotification() {
+  let content = UNMutableNotificationContent()
+  content.title = "추천 질문"
+  content.body = "오늘의 추천 질문을 확인하고, 서로에 대해 알아보는 시간을 가져보세요."
+  
+  var dateComponents = DateComponents()
+  dateComponents.timeZone = TimeZone(identifier: "Asia/Seoul")
+  
+  // 임의로 설정한 시간! 저녁 9시 50분 => 먼가 퇴근하고 쉬고 있을 것 같은 시간,,
+  dateComponents.hour = 21
+  dateComponents.minute = 50
+  
+  let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
+  print(dateComponents)
+  
+  let request = UNNotificationRequest(identifier: "dailyNotification", content: content, trigger: trigger)
+  
+  UNUserNotificationCenter.current().add(request) { error in
+    if let error = error {
+      print("Error scheduling notification: \(error)")
+    }
+  }
+}

--- a/ABloom/ABloom/LocalPushNotification.swift
+++ b/ABloom/ABloom/LocalPushNotification.swift
@@ -26,8 +26,8 @@ func requestNotificationPermission() {
 
 func scheduleDailyNotification() {
   let content = UNMutableNotificationContent()
-  content.title = "추천 질문"
-  content.body = "오늘의 추천 질문을 확인하고, 서로에 대해 알아보는 시간을 가져보세요."
+  content.title = "오늘의 추천 질문을 확인해보세요"
+  content.body = "답변을 작성하고 서로의 생각을 알아볼까요?"
   
   var dateComponents = DateComponents()
   dateComponents.timeZone = TimeZone(identifier: "Asia/Seoul")

--- a/ABloom/ABloom/LocalPushNotification.swift
+++ b/ABloom/ABloom/LocalPushNotification.swift
@@ -32,9 +32,8 @@ func scheduleDailyNotification() {
   var dateComponents = DateComponents()
   dateComponents.timeZone = TimeZone(identifier: "Asia/Seoul")
   
-  // 임의로 설정한 시간! 저녁 9시 50분 => 먼가 퇴근하고 쉬고 있을 것 같은 시간,,
   dateComponents.hour = 21
-  dateComponents.minute = 50
+  dateComponents.minute = 0
   
   let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
   print(dateComponents)


### PR DESCRIPTION
#### close #159

### ✏️ 개요
- 정해진 시간에 알림을 보내는 로컬 푸쉬 기능 구형

### 💻 작업 사항
- [x] 로컬 푸쉬 기능 구현
- [x] 임의로 커멘트 및 시간 설정
- [x] 알림 권한 허용에 관한 메시지 임의 설정 

### 📄 리뷰 노트
AppDelegate 파일에 설정해 두어야 하는데, 이전 PR에서 리팩토링하여 컨플릭트가 우려되서 다른 파일에 만들어두었습니다.
그리고 Firebase 쪽 코드와 합쳐지는 것을 고려했을 때, 아직 정확히 이해하지 못해 따로 먼저 구현해 보았습니다.
멘트나 시간에 대해서는 제이와 벤틀리한테 요청해둔 상태이고, 이번주 중에 네트워크 푸쉬도 공부하면서 합쳐보겠습니다!

이슈에 작성한 것 처럼 ON/OFF 기능 고려하면서 구현한다고 했는데, 함수 실행할 때, 설정에서 받아온 변수로 처리하면 될 듯 합니다.
아직 설정에서 셋팅하는 기능이 없어서 우선은 어떻게 할지만 구상하고 넘어갔습니다.

* 알림은 앱을 백그라운드에서 껐을 때도 동작하고, 알림을 눌렀을 때, 앱으로 바로 이동하게 됩니다!
* 적다가 생각났는데, 실행 중에도 알림이 오는지는 확인하지 않았습니다,, 안왔던것 같은데, 앱을 구동할 때는 알림이 필요없다고 생각하는데, 필요하다고 하면 따로 구현하겠습니다!
* plist 다크모드 차단한 코드가 추가되었는데, 이건 이전에 말한바와 같이 자동 생성된 파일에서 연동 될때가 있고 안될때가 있어서, 자동 생성된것 같습니다~ 제가 따로 직접 만진건 아닙니다,,

### 📱결과 화면(optional)
![추천질문멘트](https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/44897331/00ca0e11-6ac6-4253-9a2e-e9c617674d00)


### 📚 ETC(optional)
X