### PR TITLE
[Bug/#161] 성별에 따른 초상화 이미지 변경 기능 구현

### DIFF
--- a/ABloom/ABloom.xcodeproj/project.pbxproj
+++ b/ABloom/ABloom.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		3D957E902AEE7F4800D565E9 /* DBAnswerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D957E8F2AEE7F4800D565E9 /* DBAnswerModel.swift */; };
 		3D957E9C2AEF998000D565E9 /* Ex+Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D957E9B2AEF998000D565E9 /* Ex+Sequence.swift */; };
 		3D957EA52AF6B66D00D565E9 /* Ex+UIApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D957EA42AF6B66D00D565E9 /* Ex+UIApplication.swift */; };
+		3D957EA72AF8E95F00D565E9 /* UserSexType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D957EA62AF8E95F00D565E9 /* UserSexType.swift */; };
 		3DB6A5752AE0BDF800C1369F /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5742AE0BDF800C1369F /* FirebaseAnalytics */; };
 		3DB6A5772AE0BDF800C1369F /* FirebaseAnalyticsOnDeviceConversion in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5762AE0BDF800C1369F /* FirebaseAnalyticsOnDeviceConversion */; };
 		3DB6A5792AE0BDF800C1369F /* FirebaseAnalyticsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3DB6A5782AE0BDF800C1369F /* FirebaseAnalyticsSwift */; };
@@ -106,8 +107,8 @@
 		AEB502642AE5FA840056E439 /* CustomNavigationBarModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB502632AE5FA840056E439 /* CustomNavigationBarModifier.swift */; };
 		AEB5026B2AE64B8D0056E439 /* CategoryQuestionBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB5026A2AE64B8D0056E439 /* CategoryQuestionBox.swift */; };
 		AEC260612AEA5A8000DF7CD5 /* StaticQuestionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC260602AEA5A8000DF7CD5 /* StaticQuestionManager.swift */; };
-		AEE9EC762AF7C6350026D803 /* LocalPushNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE9EC752AF7C6350026D803 /* LocalPushNotification.swift */; };
 		AEC44E042AF628DF0021156E /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AEC44E032AF628DF0021156E /* Launch Screen.storyboard */; };
+		AEE9EC762AF7C6350026D803 /* LocalPushNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE9EC752AF7C6350026D803 /* LocalPushNotification.swift */; };
 		AEEA8DCF2AEB82070068550E /* SelectQuestionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEA8DCE2AEB82070068550E /* SelectQuestionViewModel.swift */; };
 		AEEA8DD12AEB82290068550E /* SelectQuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEA8DD02AEB82290068550E /* SelectQuestionView.swift */; };
 		AEEA8DD32AEB82520068550E /* ChatBubbles.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEA8DD22AEB82520068550E /* ChatBubbles.swift */; };
@@ -140,6 +141,7 @@
 		3D957E8F2AEE7F4800D565E9 /* DBAnswerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBAnswerModel.swift; sourceTree = "<group>"; };
 		3D957E9B2AEF998000D565E9 /* Ex+Sequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ex+Sequence.swift"; sourceTree = "<group>"; };
 		3D957EA42AF6B66D00D565E9 /* Ex+UIApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ex+UIApplication.swift"; sourceTree = "<group>"; };
+		3D957EA62AF8E95F00D565E9 /* UserSexType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSexType.swift; sourceTree = "<group>"; };
 		3DB6A5AA2AE0C09800C1369F /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		3DB6A5AD2AE0C12B00C1369F /* AppleLoginButtonViewRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginButtonViewRepresentable.swift; sourceTree = "<group>"; };
 		3DB6A5B02AE11C2D00C1369F /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
@@ -191,8 +193,8 @@
 		AEB502632AE5FA840056E439 /* CustomNavigationBarModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNavigationBarModifier.swift; sourceTree = "<group>"; };
 		AEB5026A2AE64B8D0056E439 /* CategoryQuestionBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryQuestionBox.swift; sourceTree = "<group>"; };
 		AEC260602AEA5A8000DF7CD5 /* StaticQuestionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticQuestionManager.swift; sourceTree = "<group>"; };
-		AEE9EC752AF7C6350026D803 /* LocalPushNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalPushNotification.swift; sourceTree = "<group>"; };
 		AEC44E032AF628DF0021156E /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
+		AEE9EC752AF7C6350026D803 /* LocalPushNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalPushNotification.swift; sourceTree = "<group>"; };
 		AEEA8DCE2AEB82070068550E /* SelectQuestionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectQuestionViewModel.swift; sourceTree = "<group>"; };
 		AEEA8DD02AEB82290068550E /* SelectQuestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectQuestionView.swift; sourceTree = "<group>"; };
 		AEEA8DD22AEB82520068550E /* ChatBubbles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatBubbles.swift; sourceTree = "<group>"; };
@@ -313,6 +315,7 @@
 			children = (
 				3D4412772AE9F5E600FD5A51 /* ServiceWebURL.swift */,
 				607DA2132AEFCF93005AE11C /* ConnectionError.swift */,
+				3D957EA62AF8E95F00D565E9 /* UserSexType.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -775,6 +778,7 @@
 				6053F1622ADF6CDE0064A6E0 /* InputFieldModifier.swift in Sources */,
 				6053F1742AE17A3A0064A6E0 /* HomeViewModel.swift in Sources */,
 				3D4412512AE4E58A00FD5A51 /* MenuView.swift in Sources */,
+				3D957EA72AF8E95F00D565E9 /* UserSexType.swift in Sources */,
 				3DB6A5B42AE11CCD00C1369F /* SignInAppleHelper.swift in Sources */,
 				3DB6A5AB2AE0C09800C1369F /* LoginView.swift in Sources */,
 				607DA2122AEF5C96005AE11C /* DeleteAccountView.swift in Sources */,

--- a/ABloom/ABloom/Presentation/BoundaryViews/Registration/View/RegistrationView.swift
+++ b/ABloom/ABloom/Presentation/BoundaryViews/Registration/View/RegistrationView.swift
@@ -65,7 +65,7 @@ extension RegistrationView {
         .fontWithTracking(.subHeadlineR)
       
       HStack(spacing: 18) {
-        ForEach(UserType.allCases, id: \.self) { user in
+        ForEach(UserSexType.allCases, id: \.self) { user in
           Button {
             registerVM.userType = user
           } label: {

--- a/ABloom/ABloom/Presentation/BoundaryViews/Registration/ViewModel/RegistrationViewModel.swift
+++ b/ABloom/ABloom/Presentation/BoundaryViews/Registration/ViewModel/RegistrationViewModel.swift
@@ -13,15 +13,6 @@ enum InputField {
   case datePicker
 }
 
-enum UserType: String, CaseIterable {
-  case woman = "예비신부"
-  case man = "예비신랑"
-  
-  var getBool: Bool {
-    self == .man ? true : false
-  }
-}
-
 enum RegisterField {
   case username
   case userType
@@ -30,7 +21,7 @@ enum RegisterField {
 
 class RegistrationViewModel: ObservableObject {
   @Published var userName: String = ""
-  @Published var userType: UserType?
+  @Published var userType: UserSexType?
   @Published var weddingDate: Date = .now
   @Published var isDatePickerTapped: Bool = false
   @Published var isShowingDatePicker = false
@@ -55,11 +46,11 @@ class RegistrationViewModel: ObservableObject {
     return isFieldValid(.datePicker, value: formattedWeddingDate)
   }
   
-  func isUserTypeValid(type: UserType) -> Bool {
+  func isUserTypeValid(type: UserSexType) -> Bool {
     isFieldValid(.radio, value: type.rawValue, selectedType: userType)
   }
   
-  private func isFieldValid(_ type: InputField, value: String, selectedType: UserType? = nil) -> Bool {
+  private func isFieldValid(_ type: InputField, value: String, selectedType: UserSexType? = nil) -> Bool {
     switch type {
     case .datePicker:
       return isDatePickerTapped

--- a/ABloom/ABloom/Presentation/CoreViews/Home/ViewModel/HomeViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Home/ViewModel/HomeViewModel.swift
@@ -16,7 +16,7 @@ enum MarriageStatus: String {
 @MainActor
 final class HomeViewModel: ObservableObject {
   @Published var fianceName: String = "UserName"
-  @Published var fianceSexType: UserType = .woman
+  @Published var fianceSexType: UserSexType = .woman
   @Published var untilWeddingDate: Int = 0
   @Published var marriageStatus: MarriageStatus = .notMarried
   @Published var qnaCount: Int = 0

--- a/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountView.swift
@@ -75,10 +75,12 @@ struct MyAccountView: View {
 extension MyAccountView {
   private var userInfo: some View {
     HStack(spacing: 15) {
-      Image("avatar_Female circle GradientBG")
-        .resizable()
-        .scaledToFit()
-        .frame(width: avatarSize)
+      if let userSex = myAccountVM.userSex {
+        Image(userSex.getGradientImage())
+          .resizable()
+          .scaledToFit()
+          .frame(width: avatarSize)
+      }
       
       VStack(alignment: .leading) {
         Text(myAccountVM.userName ?? "정보 없음")

--- a/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountViewModel.swift
@@ -10,6 +10,7 @@ import Foundation
 @MainActor
 final class MyAccountViewModel: ObservableObject {
   @Published var userName: String?
+  @Published var userSex: UserSexType?
   @Published var dDay: Int = 0
   @Published var dDayText: String = ""
   @Published var showActionSheet: Bool = false
@@ -29,6 +30,7 @@ final class MyAccountViewModel: ObservableObject {
     let user = try await UserManager.shared.getUser(userId: currentUser.uid)
     
     self.userName = user.name
+    self.userSex = (user.sex ?? false) ? .man : .woman
     updateDDayText(date: user.marriageDate ?? .now)
     self.isReady = true
   }

--- a/ABloom/ABloom/Resources/Utilities/UserSexType.swift
+++ b/ABloom/ABloom/Resources/Utilities/UserSexType.swift
@@ -1,0 +1,26 @@
+//
+//  UserSexType.swift
+//  ABloom
+//
+//  Created by 정승균 on 11/6/23.
+//
+
+import Foundation
+
+enum UserSexType: String, CaseIterable {
+  case woman = "예비신부"
+  case man = "예비신랑"
+  
+  var getBool: Bool {
+    self == .man ? true : false
+  }
+  
+  func getGradientImage() -> String {
+    switch self {
+    case .woman:
+      return "avatar_Female circle GradientBG"
+    case .man:
+      return "avatar_Male circle GradientBG"
+    }
+  }
+}


### PR DESCRIPTION
#### close #161 

### ✏️ 개요
유저가 신랑인 경우에도 메뉴 프로필 아이콘에 신부아이콘이 뜨는 현상을 해결했습니다.

### 💻 작업 사항
- View Model에 user의 Sex 값을 받을 수 있도록 프로퍼티를 추가하였습니다.
- UserType이라는 열거형을 Resources의 Utilities 그룹으로 이동 후 UserSexType으로 변경하였습니다.
- UserSexType에 초상화 이미지 이름을 가져오는 함수를 추가하였습니다.
- 유저의 Sex 값에 따라 초상화 이미지가 변경되는 로직을 구현하였습니다.

### 📄 리뷰 노트
- 유저 모델에 UserSexType를 출력하는 Method or Computed Property를 추가하여 개선할 수 있을 것 같습니다. 추후 성별이 적용되는 뷰에 적용할 수 있도록 하면 좋을 것 같습니다.

### 📱결과 화면(optional)
<img width="200" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/77708819/3fd3c72b-6d4d-4743-bcc9-04f1abe57bc9">
