### PR TITLE
[Design/#172] 문답리스트 뷰 수정

### DIFF
--- a/ABloom/ABloom.xcodeproj/project.pbxproj
+++ b/ABloom/ABloom.xcodeproj/project.pbxproj
@@ -76,6 +76,8 @@
 		605541152ADE1A9D00AD5625 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605541142ADE1A9D00AD5625 /* TabBarView.swift */; };
 		605541172ADE1ACF00AD5625 /* Tab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605541162ADE1ACF00AD5625 /* Tab.swift */; };
 		6055411A2ADE66B000AD5625 /* RegistrationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605541192ADE66B000AD5625 /* RegistrationView.swift */; };
+		606AA7622AFA910100CA5EA6 /* AnswerStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606AA7612AFA910100CA5EA6 /* AnswerStatus.swift */; };
+		60797C212AF9DD7C005375DC /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60797C202AF9DD7C005375DC /* Category.swift */; };
 		607DA20C2AEE5028005AE11C /* ImageFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607DA20B2AEE5028005AE11C /* ImageFileManager.swift */; };
 		607DA20E2AEF48AE005AE11C /* NavigationArrowLeft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607DA20D2AEF48AE005AE11C /* NavigationArrowLeft.swift */; };
 		607DA2122AEF5C96005AE11C /* DeleteAccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607DA2112AEF5C96005AE11C /* DeleteAccountView.swift */; };
@@ -108,7 +110,6 @@
 		AEB5026B2AE64B8D0056E439 /* CategoryQuestionBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB5026A2AE64B8D0056E439 /* CategoryQuestionBox.swift */; };
 		AEC260612AEA5A8000DF7CD5 /* StaticQuestionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC260602AEA5A8000DF7CD5 /* StaticQuestionManager.swift */; };
 		AEC44E042AF628DF0021156E /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AEC44E032AF628DF0021156E /* Launch Screen.storyboard */; };
-		AEE9EC762AF7C6350026D803 /* LocalPushNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE9EC752AF7C6350026D803 /* LocalPushNotification.swift */; };
 		AEEA8DCF2AEB82070068550E /* SelectQuestionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEA8DCE2AEB82070068550E /* SelectQuestionViewModel.swift */; };
 		AEEA8DD12AEB82290068550E /* SelectQuestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEA8DD02AEB82290068550E /* SelectQuestionView.swift */; };
 		AEEA8DD32AEB82520068550E /* ChatBubbles.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEA8DD22AEB82520068550E /* ChatBubbles.swift */; };
@@ -158,6 +159,8 @@
 		605541142ADE1A9D00AD5625 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
 		605541162ADE1ACF00AD5625 /* Tab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tab.swift; sourceTree = "<group>"; };
 		605541192ADE66B000AD5625 /* RegistrationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationView.swift; sourceTree = "<group>"; };
+		606AA7612AFA910100CA5EA6 /* AnswerStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerStatus.swift; sourceTree = "<group>"; };
+		60797C202AF9DD7C005375DC /* Category.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
 		607DA20B2AEE5028005AE11C /* ImageFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFileManager.swift; sourceTree = "<group>"; };
 		607DA20D2AEF48AE005AE11C /* NavigationArrowLeft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationArrowLeft.swift; sourceTree = "<group>"; };
 		607DA2112AEF5C96005AE11C /* DeleteAccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAccountView.swift; sourceTree = "<group>"; };
@@ -194,7 +197,6 @@
 		AEB5026A2AE64B8D0056E439 /* CategoryQuestionBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryQuestionBox.swift; sourceTree = "<group>"; };
 		AEC260602AEA5A8000DF7CD5 /* StaticQuestionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticQuestionManager.swift; sourceTree = "<group>"; };
 		AEC44E032AF628DF0021156E /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
-		AEE9EC752AF7C6350026D803 /* LocalPushNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalPushNotification.swift; sourceTree = "<group>"; };
 		AEEA8DCE2AEB82070068550E /* SelectQuestionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectQuestionViewModel.swift; sourceTree = "<group>"; };
 		AEEA8DD02AEB82290068550E /* SelectQuestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectQuestionView.swift; sourceTree = "<group>"; };
 		AEEA8DD22AEB82520068550E /* ChatBubbles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatBubbles.swift; sourceTree = "<group>"; };
@@ -313,8 +315,10 @@
 		3D4412762AE9F5C500FD5A51 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
-				3D4412772AE9F5E600FD5A51 /* ServiceWebURL.swift */,
+				606AA7612AFA910100CA5EA6 /* AnswerStatus.swift */,
+				60797C202AF9DD7C005375DC /* Category.swift */,
 				607DA2132AEFCF93005AE11C /* ConnectionError.swift */,
+				3D4412772AE9F5E600FD5A51 /* ServiceWebURL.swift */,
 				3D957EA62AF8E95F00D565E9 /* UserSexType.swift */,
 			);
 			path = Utilities;
@@ -736,6 +740,7 @@
 				AE8D3C612ADE3C73009899A7 /* Ex+Shape.swift in Sources */,
 				AEEA8DD32AEB82520068550E /* ChatBubbles.swift in Sources */,
 				6053F15B2ADEB7700064A6E0 /* RegistrationViewModel.swift in Sources */,
+				606AA7622AFA910100CA5EA6 /* AnswerStatus.swift in Sources */,
 				6055411A2ADE66B000AD5625 /* RegistrationView.swift in Sources */,
 				3D957E9C2AEF998000D565E9 /* Ex+Sequence.swift in Sources */,
 				6053F1762AE899320064A6E0 /* InputFields.swift in Sources */,
@@ -757,6 +762,7 @@
 				607DA2142AEFCF93005AE11C /* ConnectionError.swift in Sources */,
 				3D957E892AEE7ECF00D565E9 /* AnswerCheckViewModel.swift in Sources */,
 				6053F1712AE17A260064A6E0 /* HomeRecommendView.swift in Sources */,
+				60797C212AF9DD7C005375DC /* Category.swift in Sources */,
 				607DA2162AEFE900005AE11C /* ConnectionManager.swift in Sources */,
 				6055411A2ADE66B000AD5625 /* RegistrationView.swift in Sources */,
 				AEAB19372ADF77210057BC43 /* Buttons.swift in Sources */,

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/QuestionMainView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/QuestionMainView.swift
@@ -14,25 +14,20 @@ struct QuestionMainView: View {
     VStack {
       headerView
       
-      Spacer()
-        .frame(height: 34)
+      Spacer().frame(height: 40)
       
-      if questionVM.isEmpty {
+      switch questionVM.viewState {
+      case .isProgress:
+        ProgressView()
+          .frame(maxHeight: .infinity)
+      case .isEmpty:
         emptyListView
-          .background(backWall())
-        
-      } else if questionVM.isSorted {
+      case .isSorted:
         answeredQScroll
-          .background(backWall())
-      } else {
-        // Progress 현황확인
-        VStack {
-          ProgressView()
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(backWall())
       }
     }
+    .background(backgroundDefault())
+    
     .navigationDestination(for: Int.self, destination: { content in
       if content == 0 {
         SelectQuestionView(sex: questionVM.sex)
@@ -40,8 +35,7 @@ struct QuestionMainView: View {
         AnswerCheckView(answerCheckVM: .init(questionId: content), sex: questionVM.sex)
       }
     })
-    .background(backgroundDefault())
-    
+   
     .task {
       questionVM.getInfo()
     }
@@ -49,50 +43,44 @@ struct QuestionMainView: View {
 }
 
 extension QuestionMainView {
+  // 헤더
   private var headerView: some View {
-    // 헤더
     HStack {
       Text("우리의 문답")
         .fontWithTracking(.title3Bold)
-        .padding([.leading], 20)
       Spacer()
       // FIXME: 다른 뷰로 전환 시에는 다른 방식으로 처리해야함
       NavigationLink(value: 0) {
         Image("pencil_write_fill")
       }
-      .padding(.trailing, 17)
+      .padding(.trailing, -3)
     }
-    .padding(.top, 20)
+    .padding([.top, .horizontal], 20)
     .foregroundStyle(.stone700)
   }
   
   // 질문 목록
   private var answeredQScroll: some View {
-    
     ScrollView(.vertical) {
-      Spacer()
-        .frame(height: 30)
-      
-      LazyVStack(spacing: 30) {
-        
+      LazyVStack(spacing: 12) {
         ForEach(questionVM.questions, id: \.questionID) { question in
           NavigationLink(value: question.questionID) {
             QnAListItem(
-              categoryImg: (Category(rawValue: question.category)?.imgName)!,
+              category: Category(rawValue: question.category) ?? .child,
               question: question.content,
-              date: (questionVM.answers.last(where: { $0.questionId == question.questionID })?.date) ?? .now,
-              isAns: questionVM.checkAnswerStatus(qid: question.questionID))
+              answerStatus: questionVM.checkAnswerStatus(qid: question.questionID)
+            )
           }
+          .padding(.horizontal, 20)
         }
+        
         // 탭 바로 가려지는 부분 뷰 처리
-        Spacer()
-          .frame(height: 20)
+        Spacer().frame(height: 30)
       }
     }
   }
   
   private var emptyListView: some View {
-    
     VStack {
       VStack(spacing: 6) {
         HStack(spacing: 7) {
@@ -105,19 +93,15 @@ extension QuestionMainView {
         Text("첫번째 문답을 작성해보세요.")
       }
       .fontWithTracking(.calloutR, tracking: -0.4)
-      .foregroundStyle(.stone400)
+      .foregroundStyle(.stone500)
       .frame(maxWidth: .infinity)
-      .frame(height: 114)
-      .background(
-        RoundedRectangle(cornerRadius: 12)
-          .stroke(Color.stone300)
-          .foregroundStyle(.clear)
-      )
-      .padding(.horizontal, 20)
-      .padding(.top, 35)
+      .frame(height: 141)
+      .background(Color.white)
+      .cornerRadius(12, corners: .allCorners)
       
       Spacer()
     }
+    .padding(.horizontal, 20)
   }
 }
 

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/QuestionMainViewModel.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/ViewModel/QuestionMainViewModel.swift
@@ -7,79 +7,18 @@
 
 import SwiftUI
 
-enum Category: String, CaseIterable {
-  case communication
-  case values
-  case finance
-  case lifestyle
-  case child
-  case family
-  case sex
-  case health
-  case wedding
-  case future
-  case present
-  case past
-  
-  
-  
-  var type: String {
-    switch self {
-    case .communication: return "소통"
-    case .values: return "가치관"
-    case .finance: return "경제"
-    case .lifestyle: return "생활"
-    case .child: return "자녀"
-    case .family: return "가족"
-    case .sex: return "부부 관계"
-    case .health: return "건강"
-    case .wedding: return "결혼 준비"
-    case .future: return "미래"
-    case .present: return "현재"
-    case .past: return "과거"
-      
-    }
-  }
-  
-  
-  var imgName: String {
-    switch self {
-    case .communication:
-      return "circleIcon_isometric_chatting"
-    case .values:
-      return "circleIcon_isometic_star"
-    case .finance:
-      return "circleIcon_isometic_money"
-    case .lifestyle:
-      return "circleIcon_isometic_rice"
-    case .child:
-      return "circleIcon_isometic_dummy"
-    case .family:
-      return "circleIcon_isometic_sofa"
-    case .sex:
-      return "circleIcon_isometic_bed"
-    case .health:
-      return "circleIcon_isometic_health"
-    case .wedding:
-      return "circleIcon_isometic_love_calender"
-    case .future:
-      return "circleIcon_isometic_target"
-    case .present:
-      return "circleIcon_isometric_location"
-    case .past:
-      return "circleIcon_isometic_reversed_timer"
-    }
-  }
-}
-
 @MainActor
 final class QuestionMainViewModel: ObservableObject {
   @Published var answers: [DBAnswer] = []
   @Published var questions: [DBStaticQuestion] = []
   @Published var sex = Bool()
-  @Published var isEmpty = false
-  @Published var isSorted = false
+  @Published var viewState: ViewState = .isProgress
   
+  enum ViewState {
+    case isProgress
+    case isEmpty
+    case isSorted
+  }
   
   func getUserSex() async throws {
     let userId = try AuthenticationManager.shared.getAuthenticatedUser().uid
@@ -91,15 +30,15 @@ final class QuestionMainViewModel: ObservableObject {
   }
   
   func getInfo() {
-    self.isSorted = false
+    self.viewState = .isProgress
     clearAll()
     Task {
       try? await getUserSex()
       try? await getMyAnswers()
       try? await getFianceAnswers()
       distinctQuestions()
-      sortAnswers()
       checkQuestions()
+      sortAnswers()
     }
   }
   
@@ -122,7 +61,7 @@ final class QuestionMainViewModel: ObservableObject {
   }
   
   private func checkQuestions() {
-    self.isEmpty = self.questions.isEmpty
+    self.viewState = self.questions.isEmpty ? .isEmpty : viewState
   }
   
   private func clearAll() {
@@ -131,6 +70,8 @@ final class QuestionMainViewModel: ObservableObject {
   }
   
   private func sortAnswers() {
+    if self.viewState == .isEmpty { return }
+    
     self.answers.sort { $0.date > $1.date }
     
     let id = answers.map { $0.questionId }.uniqued()
@@ -144,8 +85,9 @@ final class QuestionMainViewModel: ObservableObject {
         }
       }
     }
-    self.isSorted = true
+    
     self.questions = newArray
+    self.viewState = .isSorted
   }
   
   private func distinctQuestions() {

--- a/ABloom/ABloom/Resources/Components/QnAListItem.swift
+++ b/ABloom/ABloom/Resources/Components/QnAListItem.swift
@@ -7,68 +7,88 @@
 
 import SwiftUI
 
-enum AnswerStatus {
-  case both
-  case onlyMe
-  case onlyFinace
-  case nobody
-}
-
 struct QnAListItem: View {
-  let categoryImg: String
+  let category: Category
   let question: String
-  let date: Date
-  let isAns: AnswerStatus
-  
-  var formattedWeddingDate: String {
-    let formatter = DateFormatter()
-    formatter.dateFormat = "yyyy년 MM월 dd일"
-    return formatter.string(from: date)
-  }
+  let answerStatus: AnswerStatus
   
   var body: some View {
-    HStack(spacing: 15) {
-      
-      Image(categoryImg)
-        .resizable()
-        .aspectRatio(contentMode: .fit)
-        .frame(width: 50, height: 50)
-        .background(
-          RoundedRectangle(cornerRadius: 17)
-            .clayMorpMDShadow()
-            .foregroundStyle(.white)
-        )
-      
-      VStack(spacing: 4) {
-        HStack {
-          Text(question)
-            .fontWithTracking(.caption1Bold)
-            .foregroundStyle(.black)
-            .lineLimit(1)
-          
-          Spacer()
-        }
-        
-        HStack(spacing: 0) {
-          Text(formattedWeddingDate)
-            .fontWithTracking(.caption2R)
-          
-          Spacer()
-          
-          switch isAns {
-          case .onlyMe:
-            Text("답변을 기다리고 있어요 >")
-              .fontWithTracking(.caption2R)
-          case .onlyFinace:
-            Text("답변해주세요 >")
-              .fontWithTracking(.caption2R)
-          case .nobody, .both:
-            EmptyView()
+    VStack(alignment: .leading, spacing: 15) {
+      HStack {
+        Text("     " + question)
+          .foregroundStyle(.stone900)
+          .fontWithTracking(.footnoteBold, lineSpacing: 2)
+          .overlay(alignment: .topLeading) {
+            Text("Q.")
+              .foregroundColor(.purple700)
+              .fontWithTracking(.subHeadlineBold)
+              .offset(y: -2)
           }
-        }
-        .foregroundStyle(.stone500)
+      }
+      .multilineTextAlignment(.leading)
+      
+      HStack(spacing: 6) {
+        categoryTag
+        
+        answerStatusTag
+        
+        Spacer()
       }
     }
-    .padding(.horizontal, 20)
+    .padding(.horizontal, 25)
+    .padding(.vertical, 24)
+    .background(Color.white)
+    .cornerRadius(12, corners: .allCorners)
   }
+}
+
+extension QnAListItem {
+  private var categoryTag: some View {
+    HStack {
+      Text("\(category.type)")
+        .fontWithTracking(.caption2R)
+        .foregroundStyle(.stone600)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+    }
+    .overlay {
+      RoundedRectangle(cornerRadius: 12)
+        .stroke(lineWidth: 1)
+        .foregroundStyle(.stone600)
+    }
+  }
+  
+  private var answerStatusTag: some View {
+    HStack(spacing: 0) {
+      if let image = answerStatus.image {
+        image
+      }
+     
+      Text("\(answerStatus.text)")
+    }
+    .fontWithTracking(.caption2R, tracking: -0.4)
+    .foregroundStyle(answerStatus.textColor)
+    .padding(.horizontal, 8)
+    .padding(.vertical, 5)
+    .background(answerStatus.backgroundColor)
+    .clipShape(RoundedRectangle(cornerRadius: 12))
+    .overlay {
+      if answerStatus == .completed {
+        RoundedRectangle(cornerRadius: 12)
+          .stroke(lineWidth: 1)
+          .foregroundStyle(.purple500)
+      }
+    }
+  }
+}
+
+#Preview {
+  VStack {
+    QnAListItem(category: .future, question: "Nobody", answerStatus: .nobody)
+    QnAListItem(category: .child, question: "onlyMe", answerStatus: .onlyMe)
+    QnAListItem(category: .child, question: "onlyFinace", answerStatus: .onlyFinace)
+    QnAListItem(category: .child, question: "both", answerStatus: .both)
+    QnAListItem(category: .child, question: "completed", answerStatus: .completed)
+  }
+  .background(.blue)
 }

--- a/ABloom/ABloom/Resources/Utilities/AnswerStatus.swift
+++ b/ABloom/ABloom/Resources/Utilities/AnswerStatus.swift
@@ -1,0 +1,60 @@
+//
+//  AnswerStatus.swift
+//  ABloom
+//
+//  Created by Lee Jinhee on 11/8/23.
+//
+
+import SwiftUI
+
+enum AnswerStatus {
+  case both
+  case onlyMe
+  case onlyFinace
+  case nobody
+  case completed
+  
+  var text: String {
+    switch self {
+    case .both:
+      return "완성해주세요"
+    case .onlyMe:
+      return "답변을 기다리고 있어요"
+    case .onlyFinace:
+      return "답변해주세요 >"
+    case .nobody:
+      return ""
+    case .completed:
+      return " 완성된 문답"
+    }
+  }
+  
+  var textColor: Color {
+    switch self {
+    case .both, .onlyMe, .onlyFinace, .nobody:
+      return .stone50
+    case .completed:
+      return .purple600
+    }
+  }
+  
+  var backgroundColor: Color {
+    switch self {
+    case .onlyMe:
+      return .purple500
+    case .both, .onlyFinace:
+      return .purple600
+    case .completed, .nobody:
+      return .white
+    }
+  }
+
+  var image: Image? {
+    switch self {
+    case .completed:
+      return Image(systemName: "checkmark")
+    case .both, .onlyMe, .onlyFinace, .nobody:
+      return nil
+    }
+  }
+}

--- a/ABloom/ABloom/Resources/Utilities/Category.swift
+++ b/ABloom/ABloom/Resources/Utilities/Category.swift
@@ -1,0 +1,67 @@
+//
+//  Category.swift
+//  ABloom
+//
+//  Created by Lee Jinhee on 11/7/23.
+//
+
+enum Category: String, CaseIterable {
+  case communication
+  case values
+  case finance
+  case lifestyle
+  case child
+  case family
+  case sex
+  case health
+  case wedding
+  case future
+  case present
+  case past
+  
+  var type: String {
+    switch self {
+    case .communication: return "소통"
+    case .values: return "가치관"
+    case .finance: return "경제"
+    case .lifestyle: return "생활"
+    case .child: return "자녀"
+    case .family: return "가족"
+    case .sex: return "부부 관계"
+    case .health: return "건강"
+    case .wedding: return "결혼 준비"
+    case .future: return "미래"
+    case .present: return "현재"
+    case .past: return "과거"
+    }
+  }
+  
+  var imgName: String {
+    switch self {
+    case .communication:
+      return "circleIcon_isometric_chatting"
+    case .values:
+      return "circleIcon_isometic_star"
+    case .finance:
+      return "circleIcon_isometic_money"
+    case .lifestyle:
+      return "circleIcon_isometic_rice"
+    case .child:
+      return "circleIcon_isometic_dummy"
+    case .family:
+      return "circleIcon_isometic_sofa"
+    case .sex:
+      return "circleIcon_isometic_bed"
+    case .health:
+      return "circleIcon_isometic_health"
+    case .wedding:
+      return "circleIcon_isometic_love_calender"
+    case .future:
+      return "circleIcon_isometic_target"
+    case .present:
+      return "circleIcon_isometric_location"
+    case .past:
+      return "circleIcon_isometic_reversed_timer"
+    }
+  }
+}


### PR DESCRIPTION
#### close #172

### ✏️ 개요
QuestionMainView에 사용되는 문답 리스트 컴포넌트와 뷰를 수정했습니다.

### 💻 작업 사항
- [x] 문답 리스트 컴포넌트 수정
- [x] 문답 리스트 확인 뷰 수정

### 📄 리뷰 노트
- QnaListItem 안에 쓰이는 태그 컴포넌트들은 다른 뷰에서 재사용되고 있지 않기 때문에 
따로 파일을 구분짓지 않고 뷰 내에 구현하였습니다.
- Enum으로 되어있는 부분을 Utilities폴더로 이동시켰습니다.
- QuestionMainView내에 뷰 상태를 관리하는 enum을 생성하여 변수 하나로 상태변화를 구분짓도록 했습니다.

### 📱결과 화면(optional)
<img src = "https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/100195563/19b7c304-8355-49f5-ab6b-50cbf124311e" width = "300"> 
<img width="237" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/100195563/73c02552-d1ca-4a98-82f4-9ced287b6990">

### 📚 ETC(optional)
Feat로 작업했는데 Design에 가까워서 라벨을 변경하였습니다요!

