### PR TITLE
[Feat/#176] AnswerWriteView 텍스트필드 및 스와이프 제한 적용

### DIFF
--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerWriteView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/AnswerWriteView.swift
@@ -99,6 +99,12 @@ extension AnswerWriteView {
           if newValue.count > 150 {
             answerVM.answerText = String(newValue.prefix(150))
           }
+          // 내용이 있을 때, 스와이프 방지
+          if !newValue.isEmpty {
+            UINavigationController.isSwipeBackEnabled = false
+          } else {
+            UINavigationController.isSwipeBackEnabled = true
+          }
         })
         .padding(.horizontal, 22)
     }

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/SelectQuestionView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/SelectQuestionView.swift
@@ -38,6 +38,8 @@ struct SelectQuestionView: View {
     })
     
     .onAppear {
+      //TODO: mainView에서도 추가해야함! 충돌일어날까봐 우선 보류
+      UINavigationController.isSwipeBackEnabled = true
       if NavigationModel.shared.isPopToMain {
         NavigationModel.shared.popToMainToggle()
         dismiss()

--- a/ABloom/ABloom/Resources/Components/ChatBubbles.swift
+++ b/ABloom/ABloom/Resources/Components/ChatBubbles.swift
@@ -78,7 +78,7 @@ struct QuestionChatBubble: View {
         .multilineTextAlignment(.leading)
         .padding(.vertical, paddingV)
         .padding(.horizontal, paddingH)
-       
+      
         .background(
           Rectangle()
             .clayMorpMDShadow()
@@ -146,27 +146,26 @@ struct ChatBubbleTextField: View {
     TextField("", text: $text, axis: .vertical)
       .placeholder(when: text.isEmpty, placeholder: {
         Text("답변을 작성해주세요. (150자 이내)")
-          .font(.custom("SpoqaHanSansNeo-Regular", size: 14))
-          .tracking(-0.2)
-          .lineSpacing(7)
+          .fontWithTracking(.chatBubble, tracking: -0.2)
           .foregroundStyle(.stone300)
       })
-      .font(.custom("SpoqaHanSansNeo-Regular", size: 14))
-      .tracking(-0.2)
-      .lineSpacing(7)
+      .fontWithTracking(.chatBubble, tracking: -0.2, lineSpacing: 7)
       .foregroundStyle(.white)
       .multilineTextAlignment(.leading)
     
       .padding(.vertical, paddingV)
       .padding(.horizontal, paddingH)
+      
+      // 텍스트 입력시 커서가 작아지면서 백그라운드도 작아지는 현상 방지를 위해 height를 조금 더 넓게 설정
+      .frame(minHeight: 45, alignment: .center)
+      .frame(maxWidth: 247, alignment: .leading)
+    
       .background(
         Rectangle()
           .clayMorpMDShadow()
           .foregroundStyle(.purple600)
           .cornerRadius(cornerV, corners: [.topLeft, .bottomRight, .bottomLeft])
       )
-      .frame(minHeight: 20, alignment: .center)
-      .frame(maxWidth: 247, alignment: .leading)
   }
 }
 
@@ -195,6 +194,7 @@ struct ChatCallout: View {
     LeftGrayChatBubble(text: "내용을 입력해주세요.")
     RightPurpleChatBubble(text: "내용을 입력해주세요.")
     ChatCallout(text: "내용")
+    //ChatBubbleTextField(text: "")
     
   }
 }

--- a/ABloom/ABloom/Resources/Extensions/Ex+UINavigation.swift
+++ b/ABloom/ABloom/Resources/Extensions/Ex+UINavigation.swift
@@ -8,13 +8,15 @@
 import SwiftUI
 
 extension UINavigationController: ObservableObject, UIGestureRecognizerDelegate {
-    override open func viewDidLoad() {
-        super.viewDidLoad()
-        navigationBar.isHidden = true
-        interactivePopGestureRecognizer?.delegate = self
-    }
-
-    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-        return viewControllers.count > 1
-    }
+  static var isSwipeBackEnabled = true
+  
+  override open func viewDidLoad() {
+    super.viewDidLoad()
+    navigationBar.isHidden = true
+    interactivePopGestureRecognizer?.delegate = self
+  }
+  
+  public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+    return viewControllers.count > 1 && Self.isSwipeBackEnabled
+  }
 }


### PR DESCRIPTION
#### close #176

### ✏️ 개요
스프린트2 AnswerWriteView 수정

### 💻 작업 사항
- 텍스트필드에서 기존 커서가 시스템 폰트로 진행되서 글자 입력 시 커서가 줄어들고, 동시에 백그라운드도 줄어드는 현상 방지를 위해 minHeight 조정했습니다. (여러가지 시도를 했지만 못찾았습니다;; 추천방법이 있을까요?)
- AnswerWriteView에서 텍스트를 입력하고 뒤로가기 버튼 클릭시 경고창이 뜨는데, 스와이프 백을 했을 때는 그런게 없어서, 그 뷰에서만 스와이프백을 못하게 처리했습니다.

### 📄 리뷰 노트
1. 텍스트필드 관련 사항 혹시 해결 방법이 있을까요? 
(overlay하는 방법도 고려했습니다만 geometryReader쓰고 일일히 조절해줘야해서, 리소스 낭비라는 생각이 들었습니다!)
2. 스와이프백 관련 QuestionMainView에서도 다시 true로 바꿔줘야하는데 라딘 코드와 충돌될 것 같아서 하지 않았습니다!
3. 스와이프백 관련 벤틀리와 이야기했던 사항이라 적용했는데, 내일 세션 중에 다시 한번 더 이야기해보겠습니다!

### 📱결과 화면(optional)
![Simulator Screenshot - iPhone 15 Pro - 2023-11-08 at 22 50 54](https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/44897331/a9bda894-d4b6-41d7-8fd4-cb6025644ca2)

### 📚 ETC(optional)
X
