### PR TITLE
[Bug/#149] 로그아웃 플로우 수정

### DIFF
--- a/ABloom/ABloom.xcodeproj/project.pbxproj
+++ b/ABloom/ABloom.xcodeproj/project.pbxproj
@@ -966,7 +966,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.abloom.ABloom;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1010,7 +1010,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.abloom.ABloom;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/ABloom/ABloom/Presentation/CoreViews/Menu/MenuView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/MenuView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct MenuView: View {
+  @Binding var selectedTab: Tab
+  
   let listItemPadding: CGFloat = 32
   let versionInfoText: String = "v1.0.0"
   
@@ -28,7 +30,7 @@ struct MenuView: View {
 
 #Preview {
   NavigationStack {
-    MenuView()
+    MenuView(selectedTab: .constant(.info))
   }
 }
 
@@ -47,7 +49,7 @@ extension MenuView {
   private var menuList: some View {
     VStack(spacing: listItemPadding) {
       MenuListNavigationItem(title: "내 계정") {
-        MyAccountView()
+        MyAccountView(selectedTab: $selectedTab)
       }
       
       MenuListNavigationItem(title: "연결 설정") {

--- a/ABloom/ABloom/Presentation/CoreViews/Menu/MenuView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/MenuView.swift
@@ -11,7 +11,7 @@ struct MenuView: View {
   @Binding var selectedTab: Tab
   
   let listItemPadding: CGFloat = 32
-  let versionInfoText: String = "v1.0.0"
+  let versionInfoText: String = "v1.1.0"
   
   var body: some View {
     NavigationStack {

--- a/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/DeleteAccountView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/DeleteAccountView.swift
@@ -11,6 +11,7 @@ struct DeleteAccountView: View {
   @Environment(\.dismiss) private var dismiss
   @State var deleteAlert: Bool = false
   @State var showLoginView = false
+  @Binding var selectedTab: Tab
 
   private let title = "메리를 탈퇴하시나요?"
   private let content1 = "지금까지 메리를 이용해주셔서 감사합니다.\n회원님께 더 나은 서비스를 제공해드리지 못한 것 같아 무거운 마음이 큽니다.\n\n"
@@ -69,6 +70,8 @@ struct DeleteAccountView: View {
       
       Button("회원 탈퇴") {
         Task {
+          dismiss()
+          selectedTab = .main
           try? await UserManager.shared.deleteUser()
           try? await AuthenticationManager.shared.delete()
           showLoginView = true
@@ -87,5 +90,5 @@ struct DeleteAccountView: View {
 }
 
 #Preview {
-  DeleteAccountView()
+  DeleteAccountView(selectedTab: .constant(.info))
 }

--- a/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/Menu/SubViews/MyAccount/MyAccountView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct MyAccountView: View {
   let avatarSize: CGFloat = 70
   @Environment(\.dismiss) private var dismiss
+  
+  @Binding var selectedTab: Tab
 
   @StateObject var myAccountVM = MyAccountViewModel()
   @State var showLoginView = false
@@ -68,7 +70,7 @@ struct MyAccountView: View {
 
 #Preview {
   NavigationView {
-    MyAccountView()
+    MyAccountView(selectedTab: .constant(.info))
   }
 }
 
@@ -152,7 +154,7 @@ extension MyAccountView {
       }
       
       MenuListNavigationItem(title: "회원탈퇴") {
-        DeleteAccountView()
+        DeleteAccountView(selectedTab: $selectedTab)
       }
     }
     .alert("로그아웃 하시겠어요?", isPresented: $myAccountVM.showSignOutCheckAlert) {
@@ -163,6 +165,8 @@ extension MyAccountView {
       
       Button("로그아웃") {
         try? myAccountVM.signOut()
+        dismiss()
+        selectedTab = .main
         showLoginView = true
         myAccountVM.showSignOutCheckAlert = false
       }

--- a/ABloom/ABloom/Presentation/CoreViews/TabBar/TabBarView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/TabBar/TabBarView.swift
@@ -33,7 +33,7 @@ struct TabBarView: View {
               QuestionMainView()
                 .tag(tab)
             case .info:
-              MenuView()
+              MenuView(selectedTab: $selectedTab)
                 .tag(tab)
             }
           }


### PR DESCRIPTION
#### close #149

### ✏️ 개요
로그아웃 후 재로그인 시 홈화면이 아닌 다른 화면으로 이동되는 이슈를 해결하였습니다.

### 💻 작업 사항
- binding을 이용하여 Tab 화면을 제어합니다.
- 버전 표시, 프로젝트 버전을 수정하였습니다.

### 📄 리뷰 노트
- 회원 탈퇴 시 플로우는 품이 많이 들어갈 것 같아, 추후 리팩토링 때 NavigationPath를 통해 구현할 수 있도록 하겠습니다!

### 📱결과 화면(optional)
<img width="200" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/77708819/5e34e4b5-b9fb-4643-b30a-944a3655f934">