### PR TITLE
[Design/#197] Tipview 레이아웃 수정

### DIFF
--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/TipView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/TipView.swift
@@ -37,11 +37,11 @@ struct TipView: View {
       Rectangle().frame(height: 1.5)
         .foregroundStyle(.stone200)
       
-      Spacer().frame(maxHeight: 56)
+      Spacer().frame(maxHeight: 50)
       
       contentView
       
-      Spacer().frame(maxHeight: 56)
+      Spacer().frame(maxHeight: 50)
       
       Button {
         isPresent = false
@@ -57,7 +57,7 @@ struct TipView: View {
       .padding(.horizontal, 32)
       .padding(.bottom, 18)
     }
-    .frame(minHeight: 400, maxHeight: 440)
+    .frame(minHeight: 352, maxHeight: 420)
     .background(Color.stone100)
     .cornerRadius(16, corners: .allCorners)
     .padding(.horizontal, 8)
@@ -70,25 +70,24 @@ struct TipView: View {
       Text(contentTitle1)
         .fontWithTracking(.calloutBold, tracking: -0.4)
       
-      Text("둘 중 한 명이라도")
-      + Text(" ‘더 대화해보고 싶어요' ")
+      Text("둘 중 한 명이라도".useNonBreakingSpace())
+      + Text(" ‘더 대화해보고 싶어요' ".useNonBreakingSpace())
         .foregroundColor(.purple600)
       + Text("나")
-      + Text(" ‘더 알아봐야겠어요' ")
+      + Text(" ‘더 알아봐야겠어요' ".useNonBreakingSpace())
         .foregroundColor(.purple600)
-      + Text("를 선택한 경우, 함께 시간을 보내며 더 얘기를 나눠주세요.")
-         
+      + Text("를 선택한 경우, 함께 시간을 보내며 더 얘기를 나눠주세요.".useNonBreakingSpace())
+      
       Text(contentTitle2)
         .fontWithTracking(.calloutBold, tracking: -0.4)
         .padding(.top, 18)
       
-      Text("함께 충분한 이야기를 나누고, 더 대화해보고 싶거나 알아보고 싶은 부분이 해결되었으면")
-      + Text(" ‘문답 완성하기' ")
+      Text("함께 충분한 이야기를 나누고, 더 대화해보고 싶거나 알아보고 싶은 부분이 해결되었으면".useNonBreakingSpace())
+      + Text(" ‘문답 완성하기' ".useNonBreakingSpace())
         .foregroundColor(.purple600)
-      + Text("를 눌러 우리의 소중한 문답을 완성해주세요.")
-
+      + Text("를 눌러 우리의 소중한 문답을 완성해주세요.".useNonBreakingSpace())
     }
-    .fontWithTracking(.subHeadlineR, tracking: -0.4, lineSpacing: 2)
+    .fontWithTracking(.subHeadlineR, tracking: -0.52, lineSpacing: 2)
     .foregroundStyle(.stone600)
     .padding(.horizontal, 32)
     

--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/TipView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/TipView.swift
@@ -16,6 +16,8 @@ struct TipView: View {
 
   var body: some View {
     VStack(spacing: 0) {
+      Spacer().frame(height: 20)
+      
       HStack {
         Spacer()
         Text(title)
@@ -29,39 +31,17 @@ struct TipView: View {
         .padding(.trailing, -12)
       }
       .foregroundStyle(.stone600)
-      .padding(.top, 20)
       .padding(.bottom, 14)
       .padding(.horizontal, 32)
       
       Rectangle().frame(height: 1.5)
         .foregroundStyle(.stone200)
       
-      VStack(alignment: .leading, spacing: 2) {
-        Text(contentTitle1)
-          .fontWithTracking(.calloutBold, tracking: -0.4)
-        
-        Text("둘 중 한 명이라도")
-        + Text(" ‘더 대화해보고 싶어요' ")
-          .foregroundColor(.purple600)
-        + Text("나")
-        + Text(" ‘더 알아봐야겠어요' ")
-          .foregroundColor(.purple600)
-        + Text("를 선택한 경우, 함께 시간을 보내며 더 얘기를 나눠주세요.")
-           
-        Text(contentTitle2)
-          .fontWithTracking(.calloutBold, tracking: -0.4)
-          .padding(.top, 12)
-        
-        Text("함께 충분한 이야기를 나누고, 더 대화해보고 싶거나 알아보고 싶은 부분이 해결되었으면")
-        + Text(" ‘문답 완성하기' ")
-          .foregroundColor(.purple600)
-        + Text("를 눌러 우리의 소중한 문답을 완성해주세요.")
-
-      }
-      .fontWithTracking(.subHeadlineR, tracking: -0.4, lineSpacing: 2)
-      .foregroundStyle(.stone600)
-      .padding(.vertical, 50)
-      .padding(.horizontal, 32)
+      Spacer().frame(maxHeight: 56)
+      
+      contentView
+      
+      Spacer().frame(maxHeight: 56)
       
       Button {
         isPresent = false
@@ -77,12 +57,41 @@ struct TipView: View {
       .padding(.horizontal, 32)
       .padding(.bottom, 18)
     }
-    .frame(height: 400)
+    .frame(minHeight: 400, maxHeight: 440)
     .background(Color.stone100)
     .cornerRadius(16, corners: .allCorners)
     .padding(.horizontal, 8)
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(Color.black.opacity(0.6))
+  }
+  
+  private var contentView: some View {
+    VStack(alignment: .leading, spacing: 2) {
+      Text(contentTitle1)
+        .fontWithTracking(.calloutBold, tracking: -0.4)
+      
+      Text("둘 중 한 명이라도")
+      + Text(" ‘더 대화해보고 싶어요' ")
+        .foregroundColor(.purple600)
+      + Text("나")
+      + Text(" ‘더 알아봐야겠어요' ")
+        .foregroundColor(.purple600)
+      + Text("를 선택한 경우, 함께 시간을 보내며 더 얘기를 나눠주세요.")
+         
+      Text(contentTitle2)
+        .fontWithTracking(.calloutBold, tracking: -0.4)
+        .padding(.top, 18)
+      
+      Text("함께 충분한 이야기를 나누고, 더 대화해보고 싶거나 알아보고 싶은 부분이 해결되었으면")
+      + Text(" ‘문답 완성하기' ")
+        .foregroundColor(.purple600)
+      + Text("를 눌러 우리의 소중한 문답을 완성해주세요.")
+
+    }
+    .fontWithTracking(.subHeadlineR, tracking: -0.4, lineSpacing: 2)
+    .foregroundStyle(.stone600)
+    .padding(.horizontal, 32)
+    
   }
 }
 


### PR DESCRIPTION
#### close #197

### ✏️ 개요
TipView레이아웃을 수정하였습니다.

### 💻 작업 사항
- [x] TipView 레이아웃 수정

### 📄 리뷰 노트
@kimyejoon 확인 부탁드림다. 자간을 -0.4로 하면 "."만 다음 줄로 넘어가서 자간을 일부 수정하였습니다.

@Hayun218 저 .useNonBreakingSpace()는 이렇게 쓰는 게 최선이겠죠?,,!?!

### 📱결과 화면(optional)
| SE | 15 plus |
|--------|--------|
| ![image](https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/100195563/2072a081-a11a-4137-b1fc-f1f09b93b8be) | ![image](https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/100195563/5e703529-3f91-4049-bcd1-6999a334aedb) |


