### PR TITLE
[Design/#205] ChatBtn 크기 및 폰트 수정

### DIFF
--- a/ABloom/ABloom/Presentation/CoreViews/QnA/View/SelectQuestionView.swift
+++ b/ABloom/ABloom/Presentation/CoreViews/QnA/View/SelectQuestionView.swift
@@ -120,7 +120,7 @@ extension SelectQuestionView {
           
           ForEach(selectQVM.filteredLists, id: \.self) { question in
             NavigationLink(value: question) {
-              QuestionChatBubble(text: question.content.useNonBreakingSpace())
+              QuestionChatBubble(text: question.content)
             }
             .padding(.horizontal, 20)
             .padding(.bottom, 17)

--- a/ABloom/ABloom/Resources/Components/ChatBubbles.swift
+++ b/ABloom/ABloom/Resources/Components/ChatBubbles.swift
@@ -71,7 +71,7 @@ struct QuestionChatBubble: View {
   var body: some View {
     HStack {
       
-      Text(text)
+      Text(text.useNonBreakingSpace())
         .fontWithTracking(.chatBubble, tracking: -0.2, lineSpacing: 7)
         .fixedSize(horizontal: false, vertical: true)
         .foregroundStyle(.stone800)
@@ -114,11 +114,11 @@ struct ChatBubbleBtn: View {
       Spacer()
       
       Text(text)
-        .fontWithTracking(.chatBubbleBtn, tracking: -0.2, lineSpacing: 7)
+        .fontWithTracking(.subHeadlineBold, tracking: -0.4)
         .foregroundStyle(.stone800)
         .multilineTextAlignment(.leading)
-        .padding(.vertical, paddingV)
-        .padding(.horizontal, paddingH)
+        .padding(.vertical, 12)
+        .padding(.horizontal, 16)
         .background(
           Rectangle()
             .clayMorpMDShadow()


### PR DESCRIPTION
#### close #205

### ✏️ 개요
챗버블 버튼 디자인 수정

### 💻 작업 사항
- ChatBubbleBtn 수정
- 문장 개행하는 모디파이어 위치를 컴포넌트 내로 수정 (QuestionSelection 에만 해당)

### 📄 리뷰 노트
문자 개행하는 모디파이어가 어디어디 쓰이는지 정리되면 컴포넌트 내에서 처리해도 좋을 것 같습니다!

### 📱결과 화면(optional)
![Simulator Screenshot - iPhone 15 Pro - 2023-11-10 at 10 41 17](https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/44897331/7b18f138-6272-4381-9c29-04b70aff3826)


### 📚 ETC(optional)
X
