### PR TITLE
[Design/#233] QnAListItem 컴포넌트 디자인 적용

### DIFF
--- a/ABloom/ABloom.xcodeproj/project.pbxproj
+++ b/ABloom/ABloom.xcodeproj/project.pbxproj
@@ -419,6 +419,7 @@
 		3DF31AD82B044E6100F0EA4E /* QnAList */ = {
 			isa = PBXGroup;
 			children = (
+				AE1AE9FA2AE51BF00010089F /* QnAListItem.swift */,
 				3DF31AEA2B0453F400F0EA4E /* QnAListView.swift */,
 			);
 			path = QnAList;
@@ -617,7 +618,6 @@
 				607DA20D2AEF48AE005AE11C /* NavigationArrowLeft.swift */,
 				6053F1752AE899320064A6E0 /* InputFields.swift */,
 				6053F1612ADF6CDE0064A6E0 /* InputFieldModifier.swift */,
-				AE1AE9FA2AE51BF00010089F /* QnAListItem.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";

--- a/ABloom/ABloom/Presentation/1.0/CoreViews/QnA/View/QuestionMainView.swift
+++ b/ABloom/ABloom/Presentation/1.0/CoreViews/QnA/View/QuestionMainView.swift
@@ -67,8 +67,7 @@ extension QuestionMainView {
         ForEach(questionVM.questions, id: \.questionID) { question in
           NavigationLink(value: question.questionID) {
             QnAListItem(
-              category: Category(rawValue: question.category) ?? .child,
-              question: question.content,
+              question: question,
               answerStatus: questionVM.checkAnswerStatus(qid: question.questionID)
             )
           }

--- a/ABloom/ABloom/Presentation/1.0/CoreViews/QnA/ViewModel/QuestionMainViewModel.swift
+++ b/ABloom/ABloom/Presentation/1.0/CoreViews/QnA/ViewModel/QuestionMainViewModel.swift
@@ -60,9 +60,7 @@ final class QuestionMainViewModel: ObservableObject {
       } else {
         return .both
       }
-    } else {
-      return .nobody
-    }
+    } 
   }
   
   private func checkQuestions() {

--- a/ABloom/ABloom/Presentation/Main/QnAList/QnAListItem.swift
+++ b/ABloom/ABloom/Presentation/Main/QnAList/QnAListItem.swift
@@ -1,0 +1,85 @@
+//
+//  QnAListItem.swift
+//  ABloom
+//
+//  Created by yun on 10/22/23.
+//
+
+import SwiftUI
+
+struct QnAListItem: View {
+  let question: DBStaticQuestion
+  let date: Date
+  let answerStatus: AnswerStatus
+  
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text(question.content.useNonBreakingSpace())
+        .foregroundStyle(.stone900)
+        .customFont(.subHeadlineB)
+        .multilineTextAlignment(.leading)
+      
+      Text(date.formatToYMD())
+        .customFont(.caption2B)
+        .foregroundStyle(.gray400)
+      
+      HStack(spacing: 6) {
+        categoryTag
+        
+        answerStatusTag
+        
+        Spacer()
+      }
+    }
+    .padding(.horizontal, 16)
+    .padding(.vertical, 20)
+    .background(Color.white)
+    .cornerRadius(12, corners: .allCorners)
+  }
+}
+
+extension QnAListItem {
+  private var categoryTag: some View {
+    HStack {
+      Text("\(question.category)")
+        .customFont(.caption2B)
+        .foregroundStyle(.gray600)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+    }
+    .overlay {
+      RoundedRectangle(cornerRadius: 14)
+        .stroke(lineWidth: 1)
+        .foregroundStyle(.gray400)
+    }
+  }
+  
+  private var answerStatusTag: some View {
+    Text("\(answerStatus.text)")
+      .customFont(.caption2B)
+      .foregroundStyle(answerStatus.textColor)
+      .padding(.horizontal, 12)
+      .padding(.vertical, 6)
+      .background(answerStatus.backgroundColor)
+      .clipShape(RoundedRectangle(cornerRadius: 14))
+      .overlay {
+        if answerStatus == .onlyMe || answerStatus == .reactOnlyMe {
+          RoundedRectangle(cornerRadius: 14)
+            .stroke(lineWidth: 1)
+            .foregroundStyle(.purple600)
+        }
+      }
+  }
+}
+
+#Preview {
+  VStack {
+    var content: String = "질문입니다질 문입니다질문입니다질문입니 다질문입니 다질문입니 다질문입니다질문입니 다질 문입니다질문입니다"
+    QnAListItem(question: DBStaticQuestion(questionID: 1, category: "경제", content: content), date: .now, answerStatus: .completed)
+    QnAListItem(question: DBStaticQuestion(questionID: 1, category: "경제", content: content), date: .now, answerStatus: .onlyFinace)
+    QnAListItem(question: DBStaticQuestion(questionID: 1, category: "경제", content: content), date: .now, answerStatus: .onlyMe)
+    QnAListItem(question: DBStaticQuestion(questionID: 1, category: "경제", content: content), date: .now, answerStatus: .reactOnlyFinace)
+    QnAListItem(question: DBStaticQuestion(questionID: 1, category: "경제", content: content), date: .now, answerStatus: .reactOnlyMe)
+  }
+  .background(Color.blue)
+}

--- a/ABloom/ABloom/Resources/Assets.xcassets/colors/StatusColor/Complete.colorset/Contents.json
+++ b/ABloom/ABloom/Resources/Assets.xcassets/colors/StatusColor/Complete.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.263",
+          "green" : "0.573",
+          "red" : "0.141"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ABloom/ABloom/Resources/Assets.xcassets/colors/StatusColor/Contents.json
+++ b/ABloom/ABloom/Resources/Assets.xcassets/colors/StatusColor/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ABloom/ABloom/Resources/Extensions/Ex+Date.swift
+++ b/ABloom/ABloom/Resources/Extensions/Ex+Date.swift
@@ -16,6 +16,12 @@ extension Date: RawRepresentable {
     self = Date(timeIntervalSinceReferenceDate: Double(rawValue) ?? 0.0)
   }
   
+  public func formatToYMD() -> String {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy년 MM월 dd일"
+    return formatter.string(from: self)
+  }
+  
   public func isSameDate(lastChangedDate: Date) -> Bool {
     var calendar = Calendar.current
     calendar.timeZone = TimeZone(identifier: "Asia/Seoul")!

--- a/ABloom/ABloom/Resources/Utilities/AnswerStatus.swift
+++ b/ABloom/ABloom/Resources/Utilities/AnswerStatus.swift
@@ -25,7 +25,7 @@ enum AnswerStatus {
     case .reactOnlyFinace:
       return "반응해주세요  >"
     case .completed:
-      return " 완성된 문답"
+      return "완성된 문답"
     }
   }
   

--- a/ABloom/ABloom/Resources/Utilities/AnswerStatus.swift
+++ b/ABloom/ABloom/Resources/Utilities/AnswerStatus.swift
@@ -8,22 +8,22 @@
 import SwiftUI
 
 enum AnswerStatus {
-  case both
   case onlyMe
   case onlyFinace
-  case nobody
+  case reactOnlyMe
+  case reactOnlyFinace
   case completed
   
   var text: String {
     switch self {
-    case .both:
-      return "완성해주세요 >"
     case .onlyMe:
       return "답변을 기다리고 있어요"
     case .onlyFinace:
-      return "답변해주세요 >"
-    case .nobody:
-      return ""
+      return "답변해주세요  >"
+    case .reactOnlyMe:
+      return "반응을 기다리고 있어요"
+    case .reactOnlyFinace:
+      return "반응해주세요  >"
     case .completed:
       return " 완성된 문답"
     }
@@ -31,30 +31,21 @@ enum AnswerStatus {
   
   var textColor: Color {
     switch self {
-    case .both, .onlyMe, .onlyFinace, .nobody:
-      return .stone50
-    case .completed:
-      return .purple600
+    case .onlyMe, .reactOnlyMe:
+      return .gray600
+    case .completed, .onlyFinace, .reactOnlyFinace:
+      return .white
     }
   }
   
   var backgroundColor: Color {
     switch self {
-    case .onlyMe:
-      return .purple500
-    case .both, .onlyFinace:
-      return .purple600
-    case .completed, .nobody:
-      return .white
-    }
-  }
-
-  var image: Image? {
-    switch self {
     case .completed:
-      return Image(systemName: "checkmark")
-    case .both, .onlyMe, .onlyFinace, .nobody:
-      return nil
+      return .complete
+    case .onlyMe, .reactOnlyMe:
+      return .white
+    case .onlyFinace, .reactOnlyFinace:
+      return .purple600
     }
   }
 }


### PR DESCRIPTION
#### close #233

### ✏️ 개요
홈화면의 QnAListItem 컴포넌트에 디자인을 적용시켰습니다.
벤틀리와 논의한대로 이번 스프린트에서도 문답 상태를 태그 방식으로 나타내기로 하였고, 그에 따라 디자인을 적용하였습니다.

### 💻 작업 사항
- [x] 문답 컴포넌트 디자인
- [x] AnswerStatus 열거형 정리
- [x] DateExtension에 "yyyy년 MM월 dd일"로 날짜를 변환하는 함수를 추가

### 📄 리뷰 노트
홈화면에 컴포넌트 그리는 작업을 하면서 수정이 더 있을 듯합니다!

### 📱결과 화면(optional)
<img width="231" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/100195563/974d20fc-0723-4242-b094-e46bf954288f">