### PR TITLE
[Feat/#252] 뷰 간 이동 구현

### DIFF
--- a/ABloom/ABloom/Presentation/Main/CreateAnswer/CategoryWaypoint/CategoryWaypointView.swift
+++ b/ABloom/ABloom/Presentation/Main/CreateAnswer/CategoryWaypoint/CategoryWaypointView.swift
@@ -9,27 +9,43 @@ import SwiftUI
 
 struct CategoryWaypointView: View {
   @StateObject var categoryWayVM = CategoryWaypointViewModel()
+  @Environment(\.dismiss) private var dismiss
+  @Binding var isSheetOn: Bool
   
   var body: some View {
-    
-    ScrollView {
-      
-      VStack(alignment: .leading, spacing: 35) {
+    NavigationStack {
+      ScrollView {
         
-        recommenedArea
-          .padding(.top, 20)
-        
-        Text("카테고리 선택하기")
-          .customFont(.headlineB)
-        
-        categoryList
-        
-        Spacer()
+        VStack(alignment: .leading, spacing: 35) {
+          
+          recommenedArea
+            .padding(.top, 20)
+          
+          Text("카테고리 선택하기")
+            .customFont(.headlineB)
+          
+          categoryList
+          
+          Spacer()
+        }
+        .padding(.horizontal, 20)
       }
-      .padding(.horizontal, 20)
-    }
-    .sheet(isPresented: $categoryWayVM.isSelectSheetOn) {
-      SelectQuestionView(selectedCategory: categoryWayVM.selectedCategory)
+      
+      .navigationDestination(isPresented: $categoryWayVM.isSelectSheetOn, destination: {
+        SelectQuestionView(isSheetOn: $isSheetOn, selectedCategory: categoryWayVM.selectedCategory)
+      }) 
+      
+      .customNavigationBar {
+        EmptyView()
+      } leftView: {
+        Button("취소") {
+          dismiss()
+        }
+        .foregroundStyle(.purple600)
+        .customFont(.calloutB)
+      } rightView: {
+        EmptyView()
+      }
     }
   }
 }
@@ -85,5 +101,5 @@ extension CategoryWaypointView {
 }
 
 #Preview {
-  CategoryWaypointView()
+  CategoryWaypointView(isSheetOn: .constant(true))
 }

--- a/ABloom/ABloom/Presentation/Main/CreateAnswer/CategoryWaypoint/CategoryWaypointViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/CreateAnswer/CategoryWaypoint/CategoryWaypointViewModel.swift
@@ -82,7 +82,3 @@ final class CategoryWaypointViewModel: ObservableObject {
 //  }
   
 }
-
-#Preview {
-  CategoryWaypointView()
-}

--- a/ABloom/ABloom/Presentation/Main/CreateAnswer/SelectQuestion/SelectQuestionViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/CreateAnswer/SelectQuestion/SelectQuestionViewModel.swift
@@ -13,12 +13,15 @@ final class SelectQuestionViewModel: ObservableObject {
   @Published var filteredLists = [DBStaticQuestion]()
   @Published var selectedQuestion: DBStaticQuestion? = nil
   @Published var isAnswerSheetOn = Bool()
+  @Published var didGetCategory = Bool()
   @Published var selectedCategory: Category = Category.communication
   
   
-  func moveToSelectedCategory(selectedCategory: Category) {
-    self.selectedCategory = selectedCategory
+  func updateSelectedCategory(new: Category) {
+    self.selectedCategory = new
+    self.didGetCategory = true
   }
+
   
   func questionClicked(selectedQ: DBStaticQuestion) {
     self.selectedQuestion = selectedQ
@@ -50,8 +53,4 @@ final class SelectQuestionViewModel: ObservableObject {
       }
     }
   }
-}
-
-#Preview {
-  SelectQuestionView(selectedCategory: Category.communication)
 }

--- a/ABloom/ABloom/Presentation/Main/CreateAnswer/WriteAnswer/WriteAnswerView.swift
+++ b/ABloom/ABloom/Presentation/Main/CreateAnswer/WriteAnswer/WriteAnswerView.swift
@@ -26,7 +26,7 @@ struct WriteAnswerView: View {
     }
     .padding(.horizontal, 20)
     
-    .interactiveDismissDisabled()
+    .interactiveDismissDisabled(writeAMV.ansText.isEmpty ? false : true)
     
     // 네비게이션바
     .customNavigationBar {

--- a/ABloom/ABloom/Presentation/Main/CreateAnswer/WriteAnswer/WriteAnswerView.swift
+++ b/ABloom/ABloom/Presentation/Main/CreateAnswer/WriteAnswer/WriteAnswerView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct WriteAnswerView: View {
   @Environment(\.dismiss) private var dismiss
   @StateObject var writeAMV = WriteAnswerViewModel()
+  @Binding var isSheetOn: Bool
   
   var question: DBStaticQuestion
   
@@ -21,8 +22,11 @@ struct WriteAnswerView: View {
       textField
       
       textNumCheck
+      
     }
     .padding(.horizontal, 20)
+    
+    .interactiveDismissDisabled()
     
     // 네비게이션바
     .customNavigationBar {
@@ -44,15 +48,15 @@ struct WriteAnswerView: View {
       Button(action: { writeAMV.completeClicked() }, label: {
         Text("완료")
           .customFont(.calloutB)
-          .foregroundStyle((writeAMV.ansText == "" || writeAMV.isTextOver) ? .gray400 : .purple700)
+          .foregroundStyle((writeAMV.ansText.isEmpty || writeAMV.isTextOver) ? .gray400 : .purple700)
       })
-      .disabled(writeAMV.ansText == "" || writeAMV.isTextOver)
+      .disabled(writeAMV.ansText.isEmpty || writeAMV.isTextOver)
     }
     
     // 백버튼 알림
-    .alert("작성을 종료할까요?", isPresented: $writeAMV.isCancelAlertOn,
-           actions: {
+    .alert("작성을 종료할까요?", isPresented: $writeAMV.isCancelAlertOn, actions: {
       Button {
+        UINavigationController.isSwipeBackEnabled = true
         dismiss()
       } label: {
         Text("나가기")
@@ -65,10 +69,10 @@ struct WriteAnswerView: View {
     })
     
     // 완료 알림
-    .alert("답변을 완료할까요?", isPresented: $writeAMV.isCompleteAlertOn,
-           actions: {
+    .alert("답변을 완료할까요?", isPresented: $writeAMV.isCompleteAlertOn, actions: {
       Button {
-        dismiss()
+        UINavigationController.isSwipeBackEnabled = true
+        isSheetOn.toggle()
       } label: {
         Text("완료하기")
       }
@@ -92,7 +96,7 @@ extension WriteAnswerView {
   
   private var textField: some View {
     TextField("", text: $writeAMV.ansText, axis: .vertical)
-      .placeholder(when: writeAMV.ansText == "", placeholder: {
+      .placeholder(when: writeAMV.ansText.isEmpty, placeholder: {
         Text("내 답변을 작성해보세요...")
           .customFont(.calloutR)
           .foregroundStyle(.gray400)
@@ -102,6 +106,8 @@ extension WriteAnswerView {
       .frame(maxWidth: .infinity)
       .onChange(of: writeAMV.ansText, perform: { _ in
         writeAMV.checkTextCount()
+        
+        
       })
   }
   
@@ -124,5 +130,7 @@ extension WriteAnswerView {
 }
 
 #Preview {
-  WriteAnswerView(question: .init(questionID: 3, category: "communication", content: "Helloodoododo"))
+  
+  WriteAnswerView(isSheetOn: .constant(true), question: .init(questionID: 3, category: "communication", content: "Helloodoododo"))
+  
 }

--- a/ABloom/ABloom/Presentation/Main/CreateAnswer/WriteAnswer/WriteAnswerViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/CreateAnswer/WriteAnswer/WriteAnswerViewModel.swift
@@ -20,6 +20,17 @@ class WriteAnswerViewModel: ObservableObject {
     } else {
       self.isTextOver = false
     }
+    
+    self.swipeDisable()
+  }
+  
+  // 백스와이프 차단
+  private func swipeDisable() {
+    if self.ansText == "" {
+      UINavigationController.isSwipeBackEnabled = true
+    } else {
+      UINavigationController.isSwipeBackEnabled = false
+    }
   }
   
   func backClicked() {

--- a/ABloom/ABloom/Presentation/Main/CreateAnswer/WriteAnswer/WriteAnswerViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/CreateAnswer/WriteAnswer/WriteAnswerViewModel.swift
@@ -21,11 +21,11 @@ class WriteAnswerViewModel: ObservableObject {
       self.isTextOver = false
     }
     
-    self.swipeDisable()
+    self.checkSwipeDisable()
   }
   
   // 백스와이프 차단
-  private func swipeDisable() {
+  private func checkSwipeDisable() {
     if self.ansText == "" {
       UINavigationController.isSwipeBackEnabled = true
     } else {

--- a/ABloom/ABloom/Presentation/Main/QnAList/QnAListView.swift
+++ b/ABloom/ABloom/Presentation/Main/QnAList/QnAListView.swift
@@ -114,7 +114,7 @@ extension QnAListView {
         .padding(.bottom, 7)
     }
     .sheet(isPresented: $qnaListVM.showCategoryWayPointSheet) {
-      CategoryWaypointView()
+      CategoryWaypointView(isSheetOn: $qnaListVM.showCategoryWayPointSheet)
     }
   }
 }


### PR DESCRIPTION
#### close #252

### ✏️ 개요
웨이포인트, 질문선택, 답변작성 뷰들간 연결 구현

### 💻 작업 사항
- 시트 자체를 끄기 위해서 Binding을 파라미터로 전달하는 형태로 구현 (dismiss는 현재 뷰만 끌 수 있음)
- 카테고리를 선택하여 들어 온 후 변경하고 작성 뷰에서 dismiss할 경우 처음 선택한 카테고리로 돌아오는 버그 해결
- 답변작성 뷰에서 텍스트가 있을 경우, 백 스와이프 방지, 스와이프 다운으로 시트 해제 방지

### 📄 리뷰 노트
답변작성 뷰에서 Alert 창은 디펄트로 하기로 해서 그대로 유지합니다!

### 📱결과 화면(optional)
뷰가 바뀌지 않아서 결과화면은 첨부하지 않았습니다.

### 📚 ETC(optional)
X