### PR TITLE
[Feat/#262] 문답리스트뷰(홈) 프로필 이미지 적용

### DIFF
--- a/ABloom/ABloom/Presentation/Main/QnAList/QnAListView.swift
+++ b/ABloom/ABloom/Presentation/Main/QnAList/QnAListView.swift
@@ -52,7 +52,6 @@ struct QnAListView: View {
         if dbUser == nil {
           activeSheet.kind = .signUp
         }
-        qnaListVM.getUserInfo()
       }
     }
   }
@@ -63,7 +62,11 @@ extension QnAListView {
     Button {
       qnaListVM.tapProfileButton()
     } label: {
-      Image("profile.circle")
+      Image(UserSexType(type: (qnaListVM.currentUser?.sex ?? true)).getAvatar())
+        .resizable()
+        .scaledToFit()
+        .clipShape(Circle())
+        .frame(width: 32)
     }
     .sheet(isPresented: $qnaListVM.showProfileSheet) {
       NavigationStack {
@@ -149,14 +152,14 @@ extension QnAListView {
     SignInView(activeSheet: activeSheet)
       .presentationDetents([.height(302)])
       .onDisappear {
-        Task { qnaListVM.getUserInfo() }
+        Task { qnaListVM.getUser() }
       }
   }
   private var signUpSheet: some View {
     SignUpView()
       .interactiveDismissDisabled()
       .onDisappear {
-        Task { qnaListVM.getUserInfo() }
+        Task { qnaListVM.getUser() }
       }
   }
 }

--- a/ABloom/ABloom/Presentation/Main/QnAList/QnAListViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/QnAList/QnAListViewModel.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 final class QnAListViewModel: ObservableObject {
+  @Published var currentUser: DBUser?
   @Published var answers: [DBAnswer] = []
   @Published var questions: [DBStaticQuestion] = []
   @Published var viewState: QnAListViewState = .isProgress
@@ -23,7 +24,7 @@ final class QnAListViewModel: ObservableObject {
   }
   
   init() {
-    getUserInfo()
+    getUser()
     getAnswers()
     getQuestions()
     if questions.isEmpty {
@@ -33,13 +34,8 @@ final class QnAListViewModel: ObservableObject {
     }
   }
   
-  func getUserInfo() {
-    Task {
-      try await UserManager.shared.fetchCurrentUser()
-      try await UserManager.shared.fetchFianceUser()
-      dump(UserManager.shared.currentUser)
-      dump(UserManager.shared.fianceUser)
-    }
+  func getUser() {
+    self.currentUser = UserManager.shared.currentUser
   }
   
   func tapProfileButton() {

--- a/ABloom/ABloom/Resources/Utilities/UserSexType.swift
+++ b/ABloom/ABloom/Resources/Utilities/UserSexType.swift
@@ -32,7 +32,7 @@ enum UserSexType: String, CaseIterable {
     case .man:
       return "MaleAvatar"
     case .none:
-      return ""
+      return "profile.circle"
     }
   }
 }


### PR DESCRIPTION
#### close #262

### ✏️ 개요
문답리스트뷰의 프로필 이미지를 적용합니다.

### 💻 작업 사항
문답리스트뷰에서 프로필이미지를 추가했습니다.

### 📄 리뷰 노트
없쓰으음니다!

### 📱결과 화면(optional)
<img src = "https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/100195563/7be8d48a-887b-4d65-8e80-534eef75eb82" width = "300"> 