### PR TITLE
[Feat/#261] 문답리스트뷰 문답 데이터 연결 

### DIFF
--- a/ABloom/ABloom/ABloomApp.swift
+++ b/ABloom/ABloom/ABloomApp.swift
@@ -15,8 +15,8 @@ struct ABloomApp: App {
   
   init() {
     Task {
-      try? await UserManager.shared.fetchFianceUser()
       try? await UserManager.shared.fetchCurrentUser()
+      try? await UserManager.shared.fetchFianceUser()
       try? await StaticQuestionManager.shared.fetchStaticQuestions()
       StaticQuestionManager.shared.fetchFilterQuestions()
       try? await EssentialQuestionManager.shared.fetchEssentialCollections()

--- a/ABloom/ABloom/Presentation/Main/QnAList/QnAListItem.swift
+++ b/ABloom/ABloom/Presentation/Main/QnAList/QnAListItem.swift
@@ -41,7 +41,7 @@ struct QnAListItem: View {
 extension QnAListItem {
   private var categoryTag: some View {
     HStack {
-      Text("\(question.category)")
+      Text(Category(rawValue: question.category)?.type ?? "")
         .customFont(.caption2B)
         .foregroundStyle(.gray600)
         .padding(.horizontal, 12)
@@ -63,7 +63,7 @@ extension QnAListItem {
       .background(answerStatus.backgroundColor)
       .clipShape(RoundedRectangle(cornerRadius: 14))
       .overlay {
-        if answerStatus == .onlyMe || answerStatus == .reactOnlyMe {
+        if answerStatus.isStroke {
           RoundedRectangle(cornerRadius: 14)
             .stroke(lineWidth: 1)
             .foregroundStyle(.purple600)
@@ -73,7 +73,7 @@ extension QnAListItem {
 }
 
 #Preview {
-  VStack {
+  ScrollView {
     let content: String = "질문입니다질 문입니다질문입니다질문입니 다질문입니 다질문입니다질문입니다질문입니다질문입니다"
     let mockDBStaticQuestion = DBStaticQuestion(questionID: 1, category: "경제", content: content)
     
@@ -82,6 +82,8 @@ extension QnAListItem {
     QnAListItem(question: mockDBStaticQuestion, date: .now, answerStatus: .onlyMe)
     QnAListItem(question: mockDBStaticQuestion, date: .now, answerStatus: .reactOnlyFinace)
     QnAListItem(question: mockDBStaticQuestion, date: .now, answerStatus: .reactOnlyMe)
+    QnAListItem(question: mockDBStaticQuestion, date: .now, answerStatus: .moreCommunication)
+    QnAListItem(question: mockDBStaticQuestion, date: .now, answerStatus: .moreResearch)
   }
   .background(Color.blue)
 }

--- a/ABloom/ABloom/Presentation/Main/QnAList/QnAListView.swift
+++ b/ABloom/ABloom/Presentation/Main/QnAList/QnAListView.swift
@@ -52,7 +52,6 @@ struct QnAListView: View {
         if dbUser == nil {
           activeSheet.kind = .signUp
         }
-        qnaListVM.getUserInfo()
       }
     }
   }
@@ -63,7 +62,11 @@ extension QnAListView {
     Button {
       qnaListVM.tapProfileButton()
     } label: {
-      Image("profile.circle")
+      Image(UserSexType(type: (qnaListVM.currentUser?.sex ?? true)).getAvatar())
+        .resizable()
+        .scaledToFit()
+        .clipShape(Circle())
+        .frame(width: 32)
     }
     .sheet(isPresented: $qnaListVM.showProfileSheet) {
       NavigationStack {
@@ -149,14 +152,14 @@ extension QnAListView {
     SignInView(activeSheet: activeSheet)
       .presentationDetents([.height(302)])
       .onDisappear {
-        Task { qnaListVM.getUserInfo() }
+        Task { qnaListVM.getUser() }
       }
   }
   private var signUpSheet: some View {
     SignUpView()
       .interactiveDismissDisabled()
       .onDisappear {
-        Task { qnaListVM.getUserInfo() }
+        Task { qnaListVM.getUser() }
       }
   }
 }

--- a/ABloom/ABloom/Presentation/Main/QnAList/QnAListView.swift
+++ b/ABloom/ABloom/Presentation/Main/QnAList/QnAListView.swift
@@ -53,6 +53,7 @@ struct QnAListView: View {
           activeSheet.kind = .signUp
         }
       }
+      qnaListVM.fetchData()
     }
   }
 }
@@ -79,14 +80,14 @@ extension QnAListView {
   private var scrollView: some View {
     ScrollView(.vertical) {
       LazyVStack(spacing: 12) {
-        ForEach(qnaListVM.questions, id: \.questionID) { question in
+        ForEach(Array(qnaListVM.coupleAnswers), id: \.key) { question, answers in
           Button {
             qnaListVM.tapQnAListItem()
           } label: {
             QnAListItem(
               question: question,
-              date: .now,
-              answerStatus: qnaListVM.checkAnswerStatus(qid: question.questionID)
+              date: answers[0].date,
+              answerStatus: qnaListVM.checkAnswerStatus(question: question)
             )
           }
           .sheet(isPresented: $qnaListVM.showQnASheet) {
@@ -152,14 +153,14 @@ extension QnAListView {
     SignInView(activeSheet: activeSheet)
       .presentationDetents([.height(302)])
       .onDisappear {
-        Task { qnaListVM.getUser() }
+        Task { await qnaListVM.fetchDataAfterSignIn() }
       }
   }
   private var signUpSheet: some View {
     SignUpView()
       .interactiveDismissDisabled()
       .onDisappear {
-        Task { qnaListVM.getUser() }
+        Task { await qnaListVM.fetchDataAfterSignIn() }
       }
   }
 }

--- a/ABloom/ABloom/Presentation/Main/QnAList/QnAListView.swift
+++ b/ABloom/ABloom/Presentation/Main/QnAList/QnAListView.swift
@@ -104,7 +104,7 @@ extension QnAListView {
   
   private var emptyView: some View {
     VStack(spacing: 12) {
-      Image(systemName: "stop.fill")
+      Image("LogoPurple")
         .resizable()
         .frame(width: 68, height: 68)
         .padding(.bottom, 4)

--- a/ABloom/ABloom/Presentation/Main/QnAList/QnAListViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/QnAList/QnAListViewModel.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 final class QnAListViewModel: ObservableObject {
+  @Published var currentUser: DBUser?
   @Published var answers: [DBAnswer] = []
   @Published var questions: [DBStaticQuestion] = []
   @Published var viewState: QnAListViewState = .isProgress
@@ -23,7 +24,7 @@ final class QnAListViewModel: ObservableObject {
   }
   
   init() {
-    getUserInfo()
+    getUser()
     getAnswers()
     getQuestions()
     if questions.isEmpty {
@@ -33,13 +34,8 @@ final class QnAListViewModel: ObservableObject {
     }
   }
   
-  func getUserInfo() {
-    Task {
-      try await UserManager.shared.fetchCurrentUser()
-      try await UserManager.shared.fetchFianceUser()
-      dump(UserManager.shared.currentUser)
-      dump(UserManager.shared.fianceUser)
-    }
+  func getUser() {
+    self.currentUser = UserManager.shared.currentUser
   }
   
   func tapProfileButton() {

--- a/ABloom/ABloom/Presentation/Main/QnAList/QnAListViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/QnAList/QnAListViewModel.swift
@@ -7,10 +7,11 @@
 
 import SwiftUI
 
+@MainActor
 final class QnAListViewModel: ObservableObject {
   @Published var currentUser: DBUser?
-  @Published var answers: [DBAnswer] = []
-  @Published var questions: [DBStaticQuestion] = []
+  @Published var coupleAnswers: [DBStaticQuestion: [DBAnswer]] = [:]
+  
   @Published var viewState: QnAListViewState = .isProgress
 
   @Published var showProfileSheet: Bool = false
@@ -23,19 +24,137 @@ final class QnAListViewModel: ObservableObject {
     case isSorted
   }
   
-  init() {
-    getUser()
-    getAnswers()
-    getQuestions()
-    if questions.isEmpty {
+  func fetchData() {
+    Task {
+      getCurrentUser()
+      await getQuestions()
+      await getAnswers()
+    }
+  }
+  
+  func fetchDataAfterSignIn() async {
+    try? await UserManager.shared.fetchCurrentUser()
+    viewState = .isProgress
+    fetchData()
+  }
+  
+  private func getCurrentUser() {
+    self.currentUser = UserManager.shared.currentUser
+  }
+  
+  private func getQuestions() async {
+    try? await StaticQuestionManager.shared.fetchStaticQuestions()
+  }
+  
+  private func getAnswers() async {
+    try? await AnswerManager.shared.fetchMyAnswers()
+    try? await AnswerManager.shared.fetchFianceAnswers()
+
+    appendCoupleAnswers()
+    
+    sortAnswers()
+  }
+  
+  private func appendCoupleAnswers() {
+    appendMyAnswers()
+    appendFianceAnswers()
+    
+    if coupleAnswers.isEmpty {
+      self.viewState = .isEmpty
+    }
+  }
+  
+  private func appendMyAnswers() {
+    guard let myAnswers = AnswerManager.shared.myAnswers else { return }
+    
+    for myAnswer in myAnswers {
+      if let dbQuestion = getQuestions(qid: myAnswer.questionId) {
+                
+        if var answersForQuestion = coupleAnswers[dbQuestion] {
+          answersForQuestion.append(myAnswer)
+          coupleAnswers[dbQuestion] = answersForQuestion
+        } else {
+          coupleAnswers[dbQuestion] = [myAnswer]
+        }
+      }
+    }
+  }
+  
+  private func appendFianceAnswers() {
+    guard let fianceAnswers = AnswerManager.shared.fianceAnswers else { return }
+    for fianceAnswer in fianceAnswers {
+
+      if let dbQuestion = getQuestions(qid: fianceAnswer.questionId) {
+        
+        if var answersForQuestion = coupleAnswers[dbQuestion] {
+          answersForQuestion.append(fianceAnswer)
+          coupleAnswers[dbQuestion] = answersForQuestion
+        } else {
+          coupleAnswers[dbQuestion] = [fianceAnswer]
+        }
+        
+        if self.coupleAnswers[dbQuestion]?.count == 2 {
+          self.coupleAnswers[dbQuestion]?.sort(by: { $0.date > $1.date })
+        }
+      }
+    }
+  }
+  
+  private func getQuestions(qid: Int) -> DBStaticQuestion? {
+    guard let staticQuestions = StaticQuestionManager.shared.staticQuestions else {
+      return nil
+    }
+    
+    return staticQuestions.first { question in
+      question.questionID == qid
+    }
+  }
+  
+  private func sortAnswers() {
+    let answers = self.coupleAnswers.sorted { $0.value[0].date > $1.value[0].date }
+    self.coupleAnswers = Dictionary(uniqueKeysWithValues: answers)
+    if coupleAnswers.isEmpty {
       viewState = .isEmpty
     } else {
       viewState = .isSorted
     }
   }
   
-  func getUser() {
-    self.currentUser = UserManager.shared.currentUser
+  func checkAnswerStatus(question: DBStaticQuestion) -> AnswerStatus {
+    guard let coupleAnswer = self.coupleAnswers[question] else { return .error }
+    guard let myId = UserManager.shared.currentUser?.userId else { return .error }
+    
+    if coupleAnswer.count == 1 {
+      if coupleAnswer[0].userId == myId {
+        return .onlyMe
+      } else {
+        return .onlyFinace
+      }
+    } else if coupleAnswer.count == 2 {
+      
+      let coupleReaction0 = coupleAnswer[0].reactionType
+      let coupleReaction1 = coupleAnswer[1].reactionType
+      
+      if coupleReaction0 != .error && coupleReaction1 != .error {
+        if coupleReaction0.isPositiveReact() && coupleReaction1.isPositiveReact() {
+          return .completed
+        } else if [coupleReaction0, coupleReaction1].contains(.moreCommunication) {
+          return .moreCommunication
+        } else {
+          return .moreResearch
+        }
+      }
+      
+      if coupleAnswer[0].reaction == nil && coupleAnswer[1].reaction == nil {
+        return .reactOnlyFinace
+      }
+      if coupleAnswer[0].reaction != nil && coupleAnswer[0].userId == myId {
+        return .reactOnlyMe
+      } else {
+        return .reactOnlyFinace
+      }
+    }
+    return .error
   }
   
   func tapProfileButton() {
@@ -48,17 +167,5 @@ final class QnAListViewModel: ObservableObject {
   
   func tapPlusButton() {
     showCategoryWayPointSheet = true
-  }
-  
-  func checkAnswerStatus(qid: Int) -> AnswerStatus {
-    return .completed
-  }
-  
-  func getAnswers() {
-    
-  }
-  
-  func getQuestions() {
-    
   }
 }

--- a/ABloom/ABloom/Resources/Assets.xcassets/Images/LogoPurple.imageset/Contents.json
+++ b/ABloom/ABloom/Resources/Assets.xcassets/Images/LogoPurple.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "MeryLogo_Flat_Purple600@SVG.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ABloom/ABloom/Resources/Assets.xcassets/Images/LogoPurple.imageset/MeryLogo_Flat_Purple600@SVG.svg
+++ b/ABloom/ABloom/Resources/Assets.xcassets/Images/LogoPurple.imageset/MeryLogo_Flat_Purple600@SVG.svg
@@ -1,0 +1,29 @@
+<svg width="60" height="61" viewBox="0 0 60 61" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_dii_582_4480)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M19.0379 41.6612L9.79224 47.8274C8.95236 48.385 7.98416 48.6673 7.01363 48.6673C6.20174 48.6673 5.38753 48.4713 4.64563 48.0724C3.01486 47.1975 2 45.5037 2 43.6536V8.99904C2 5.14024 5.14023 2 8.99902 2H36.9951C40.8539 2 43.9941 5.14024 43.9941 8.99904V41.6612H19.0379ZM57.9922 52.9857V18.3311C57.9922 14.4723 54.8519 11.3321 50.9931 11.3321H48.6601V46.3273H20.4494L15.998 49.2972V50.9933H40.9542L50.2022 57.1618C51.0398 57.7194 52.008 58.0017 52.9785 58.0017C53.7904 57.9993 54.6046 57.8034 55.3465 57.4044C56.9773 56.5295 57.9922 54.8358 57.9922 52.9857ZM31.3226 10.4384C32.8829 10.8541 34.262 11.7968 35.2382 13.1149C36.2677 14.5012 36.8118 16.2338 36.8118 18.1247C36.8118 20.846 35.2326 23.8328 32.1185 27.0016C29.581 29.5838 26.5811 31.6985 25.0213 32.7289C24.4712 33.0907 23.8319 33.283 23.1788 33.283C22.5258 33.283 21.8864 33.0907 21.3363 32.7289C19.7752 31.6985 16.7766 29.5838 14.2391 27.0016C11.125 23.8315 9.54582 20.846 9.54582 18.1247C9.54582 16.2338 10.0899 14.5012 11.1194 13.1149C12.0956 11.7968 13.4747 10.8541 15.035 10.4384C16.5953 10.0226 18.2464 10.158 19.7228 10.8226C21.0443 11.4055 22.2229 12.3936 23.1788 13.7081C24.1347 12.3968 25.3133 11.4087 26.6348 10.8226C28.1113 10.158 29.7623 10.0226 31.3226 10.4384Z" fill="#996DB0"/>
+</g>
+<defs>
+<filter id="filter0_dii_582_4480" x="0.287189" y="0.886673" width="59.4178" height="59.4273" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="0.599484"/>
+<feGaussianBlur stdDeviation="0.856405"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_582_4480"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_582_4480" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.256922" dy="0.0856405"/>
+<feGaussianBlur stdDeviation="0.642304"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.6 0"/>
+<feBlend mode="overlay" in2="shape" result="effect2_innerShadow_582_4480"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-0.256922"/>
+<feGaussianBlur stdDeviation="0.428203"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.47 0"/>
+<feBlend mode="overlay" in2="effect2_innerShadow_582_4480" result="effect3_innerShadow_582_4480"/>
+</filter>
+</defs>
+</svg>

--- a/ABloom/ABloom/Resources/Utilities/AnswerStatus.swift
+++ b/ABloom/ABloom/Resources/Utilities/AnswerStatus.swift
@@ -13,6 +13,9 @@ enum AnswerStatus {
   case reactOnlyMe
   case reactOnlyFinace
   case completed
+  case moreCommunication
+  case moreResearch
+  case error
   
   var text: String {
     switch self {
@@ -26,14 +29,20 @@ enum AnswerStatus {
       return "반응해주세요  >"
     case .completed:
       return "완성된 문답"
+    case .moreCommunication:
+      return "더 대화해보세요"
+    case .moreResearch:
+      return "더 알아보세요"
+    case .error:
+      return ""
     }
   }
   
   var textColor: Color {
     switch self {
-    case .onlyMe, .reactOnlyMe:
+    case .onlyMe, .reactOnlyMe, .moreResearch, .moreCommunication:
       return .gray600
-    case .completed, .onlyFinace, .reactOnlyFinace:
+    case .completed, .onlyFinace, .reactOnlyFinace, .error:
       return .white
     }
   }
@@ -42,10 +51,19 @@ enum AnswerStatus {
     switch self {
     case .completed:
       return .complete
-    case .onlyMe, .reactOnlyMe:
+    case .onlyMe, .reactOnlyMe, .moreResearch, .moreCommunication, .error:
       return .white
     case .onlyFinace, .reactOnlyFinace:
       return .purple600
+    }
+  }
+  
+  var isStroke: Bool {
+    switch self {
+    case .onlyMe, .reactOnlyMe, .moreResearch, .moreCommunication:
+      return true
+    case .completed, .onlyFinace, .reactOnlyFinace, .error:
+      return false
     }
   }
 }

--- a/ABloom/ABloom/Resources/Utilities/UserSexType.swift
+++ b/ABloom/ABloom/Resources/Utilities/UserSexType.swift
@@ -32,7 +32,7 @@ enum UserSexType: String, CaseIterable {
     case .man:
       return "MaleAvatar"
     case .none:
-      return ""
+      return "profile.circle"
     }
   }
 }


### PR DESCRIPTION
#### close #261

### ✏️ 개요
문답리스트뷰의 문답 데이터를 연결합니다.

### 💻 작업 사항
- [x] 문답 리스트 불러오기/정렬
- [x] 문답 없을 경우 에셋 추가
- [x] 문답 상태 추가(error, moreCommunication, moreResearch) 
- [x] 문답 상태에 따른 반응 연결
- [x] 문답 리스트 아이템 카테고리 및 날짜 적용
 
### 📄 리뷰 노트
Static질문을 fetch하지 않으면 다른 부분이 동작을 안해서 이 뷰에서도 하도록 해두었습니다..
커플문답이 [질문:[답변]]으로 구성되도록,,,해두었음다...
문답 상태 코드가 개빡시잉디...상태에 따라 다 맞게 나오는지는 다음 작업에서 확인하면서 다시 수정하겠음다..

### 📱결과 화면(optional)
<img width="289" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/100195563/5058ae1b-787a-4b37-9f2d-ff02374f6746">

<img src = "https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/100195563/c35f937f-66fc-4e9c-b65e-10409bf843d6" width = "300"> 