### PR TITLE
[Feat/#270] 프로필 메뉴 및 회원가입에서 가능한 입출력 동작과 뷰 간의 Source of truth를 유지할 수 있도록 로직 구현

### DIFF
--- a/ABloom/ABloom/Firebase/Authentication/AuthenticationManager.swift
+++ b/ABloom/ABloom/Firebase/Authentication/AuthenticationManager.swift
@@ -60,6 +60,10 @@ final class AuthenticationManager {
   /// 로컬 Firebase에 저장된 유저 정보를 삭제하고 로그아웃 합니다.
   func signOut() throws {
     try Auth.auth().signOut()
+    Task {
+      try? await UserManager.shared.fetchCurrentUser()
+      try? await UserManager.shared.fetchFianceUser()
+    }
   }
   
   /// 회원 탈퇴를 위한 로직을 구현한 메서드입니다.

--- a/ABloom/ABloom/Firebase/Firestore/AnswerManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/AnswerManager.swift
@@ -9,6 +9,7 @@ import FirebaseFirestore
 import FirebaseFirestoreSwift
 import Foundation
 
+@MainActor
 final class AnswerManager: ObservableObject {
   @Published var myAnswers: [DBAnswer]?
   @Published var fianceAnswers: [DBAnswer]?

--- a/ABloom/ABloom/Firebase/Firestore/ConnectionManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/ConnectionManager.swift
@@ -7,6 +7,7 @@
 
 import FirebaseFirestore
 
+@MainActor
 final class ConnectionManager {
   static let shared = ConnectionManager()
   @Published var isConnected: Bool = false

--- a/ABloom/ABloom/Firebase/Firestore/ConnectionManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/ConnectionManager.swift
@@ -49,6 +49,8 @@ final class ConnectionManager {
     }
     
     try await connectionUpdate(userId: currentUser.userId, targetId: targetUserId)
+    try await UserManager.shared.fetchCurrentUser()
+    try await UserManager.shared.fetchFianceUser()
   }
   
   private func connectionUpdate(userId: String, targetId: String) async throws {

--- a/ABloom/ABloom/Firebase/Firestore/StaticQuestionManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/StaticQuestionManager.swift
@@ -7,6 +7,7 @@ import FirebaseFirestore
 import FirebaseFirestoreSwift
 import Foundation
 
+@MainActor
 final class StaticQuestionManager {
   static let shared = StaticQuestionManager()
   

--- a/ABloom/ABloom/Firebase/Firestore/UserManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/UserManager.swift
@@ -30,6 +30,9 @@ final class UserManager: ObservableObject {
   // MARK: Create
   func createUser(user: DBUser) throws {
     try userDocument(userId: user.userId).setData(from: user, merge: false)
+    Task {
+      try? await fetchCurrentUser()
+    }
   }
   
   
@@ -104,6 +107,11 @@ final class UserManager: ObservableObject {
     
     let data: [String: Any?] = [DBUser.CodingKeys.fiance.rawValue: nil]
     try await userDocument(userId: fiance).updateData(data as [AnyHashable: Any])
+    
+    Task {
+      try? await fetchCurrentUser()
+      try? await fetchFianceUser()
+    }
   }
   
   private func deleteSubCollection(userId: String) async throws {
@@ -194,6 +202,4 @@ final class UserManager: ObservableObject {
     
     userAnswerCollection(userId: userId).document(answerId).updateData(data)
   }
-  
-  // FCMToken
 }

--- a/ABloom/ABloom/Firebase/Firestore/UserManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/UserManager.swift
@@ -36,13 +36,17 @@ final class UserManager: ObservableObject {
   // MARK: Retrieve
   func fetchCurrentUser() async throws {
     // TODO: 에러처리
-    let currentUser = try AuthenticationManager.shared.getAuthenticatedUser()
-    
-    self.currentUser = try await getUser(userId: currentUser.uid)
+    do {
+      let currentUser = try AuthenticationManager.shared.getAuthenticatedUser()
+      self.currentUser = try await getUser(userId: currentUser.uid)
+    } catch {
+      self.currentUser = nil
+    }
   }
   
   func fetchFianceUser() async throws {
     guard let fianceId = self.currentUser?.fiance else {
+      self.fianceUser = nil
       return
     }
     

--- a/ABloom/ABloom/Firebase/Firestore/UserManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/UserManager.swift
@@ -66,13 +66,15 @@ final class UserManager: ObservableObject {
     
     Task {
       try? await fetchCurrentUser()
-      print("내 이름 : \(self.fianceUser?.name)")
     }
   }
   
   func updateMarriageDate(userId: String, date: Date) throws {
     let data: [String: Any] = [DBUser.CodingKeys.marriageDate.rawValue:date]
     userDocument(userId: userId).updateData(data)
+    Task {
+      try? await fetchCurrentUser()
+    }
   }
   
   func updateFcmToken(userID: String, fcmToken: String) throws {

--- a/ABloom/ABloom/Firebase/Firestore/UserManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/UserManager.swift
@@ -9,6 +9,7 @@ import FirebaseFirestore
 import FirebaseFirestoreSwift
 import Foundation
 
+@MainActor
 final class UserManager: ObservableObject {
   static let shared = UserManager()
   
@@ -58,6 +59,11 @@ final class UserManager: ObservableObject {
   func updateUserName(userId: String, name: String) throws {
     let data: [String: Any] = [DBUser.CodingKeys.name.rawValue:name]
     userDocument(userId: userId).updateData(data)
+    
+    Task {
+      try? await fetchCurrentUser()
+      print("내 이름 : \(self.fianceUser?.name)")
+    }
   }
   
   func updateMarriageDate(userId: String, date: Date) throws {

--- a/ABloom/ABloom/Presentation/Main/Menu/Connection/ConnectionViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/Menu/Connection/ConnectionViewModel.swift
@@ -34,8 +34,6 @@ final class ConnectionViewModel: ObservableObject {
     Task {
       do {
         try await ConnectionManager.shared.connectFiance(connectionCode: self.inputText)
-        try? await UserManager.shared.fetchCurrentUser()
-        try? await UserManager.shared.fetchFianceUser()
         getUsers()
       } catch let error as ConnectionError {
         self.errorMessage = error.errorMessage()

--- a/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuView.swift
+++ b/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuView.swift
@@ -135,6 +135,14 @@ extension ProfileMenuView {
           Text("\(fianceName)님의 \((vm.currentUser?.sex ?? true) ? UserSexType.man.rawValue : UserSexType.woman.rawValue)")
             .customFont(.caption1B)
             .foregroundStyle(.gray500)
+        } else if vm.isSignedIn {
+          NavigationLink {
+            ConnectionView()
+          } label: {
+            Text("눌러서 연결하기 >")
+              .customFont(.caption1B)
+              .foregroundStyle(.gray500)
+          }
         } else {
           Button {
             showProfileMenuSheet = false

--- a/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuView.swift
+++ b/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuView.swift
@@ -242,7 +242,7 @@ extension ProfileMenuView {
   private var exitAction: some View {
     VStack(alignment: .leading, spacing: 20) {
       Button {
-        try? vm.signOut()
+        vm.showSignOutAlert = true
       } label: {
         listRowLabel(title: "로그아웃")
       }
@@ -254,6 +254,18 @@ extension ProfileMenuView {
       }
     }
     .padding(.horizontal, 20)
+    
+    .alert("로그아웃할까요?", isPresented: $vm.showSignOutAlert, actions: {
+      Button("취소", role: .cancel) {
+        vm.showSignOutAlert = false
+      }
+      
+      Button("로그아웃", role: .destructive) {
+        try? vm.signOut()
+      }
+    }, message: {
+      Text("로그아웃하더라도 데이터는 보관되니\n안심하고 로그아웃하셔도 돼요.")
+    })
   }
   
   private var menuSeparator: some View {

--- a/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuView.swift
+++ b/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuView.swift
@@ -89,21 +89,24 @@ struct ProfileMenuView: View {
     
     // 결혼 일자 수정
     .sheet(isPresented: $vm.showCalendarSheet) {
-      DatePicker("", selection: $vm.marriageDate, displayedComponents: .date)
-        .datePickerStyle(.graphical)
-        .frame(width: 320)
-        .labelsHidden()
-        .presentationDetents([.medium])
-      
-      Button {
-        Task {
-          try? vm.updateMyMarriageDate()
-          try? await vm.renewInfo()
-          vm.showActionSheet = false
+      VStack {
+        DatePicker("", selection: $vm.marriageDate, displayedComponents: .date)
+          .datePickerStyle(.graphical)
+          .frame(width: 320)
+          .labelsHidden()
+          .presentationDetents([.medium])
+        
+        Button {
+          Task {
+            try? vm.updateMyMarriageDate()
+            try? await vm.renewInfo()
+            vm.showActionSheet = false
+          }
+        } label: {
+          Text("완료")
         }
-      } label: {
-        Text("완료")
       }
+      .tint(.purple700)
     }
   }
 }

--- a/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuViewModel.swift
@@ -5,6 +5,7 @@
 //  Created by 정승균 on 11/20/23.
 //
 
+import Combine
 import Foundation
 
 @MainActor
@@ -20,14 +21,28 @@ final class ProfileMenuViewModel: ObservableObject {
   @Published var nameChangeTextfield = ""
   @Published var marriageDate: Date = Date()
   
+  private var cancellables = Set<AnyCancellable>()
+  
   init() {
     getUsers()
     updateDayStatus()
   }
   
   func getUsers() {
-    self.currentUser = UserManager.shared.currentUser
-    self.fianceUser = UserManager.shared.fianceUser
+//    self.currentUser = UserManager.shared.currentUser
+//    self.fianceUser = UserManager.shared.fianceUser
+    
+    UserManager.shared.$currentUser
+      .sink { [weak self] user in
+        self?.currentUser = user
+      }
+      .store(in: &cancellables)
+    
+    UserManager.shared.$fianceUser
+      .sink { [weak self] user in
+        self?.fianceUser = user
+      }
+      .store(in: &cancellables)
   }
   
   func renewInfo() async throws {

--- a/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuViewModel.swift
@@ -12,20 +12,34 @@ import Foundation
 final class ProfileMenuViewModel: ObservableObject {
   @Published var currentUser: DBUser?
   @Published var fianceUser: DBUser?
-  @Published var marriageStatus: MarriageStatus?
   
   @Published var showActionSheet = false
   @Published var showNameChangeAlert = false
   @Published var showCalendarSheet = false
+  @Published var showSignOutAlert = false
   
   @Published var nameChangeTextfield = ""
   @Published var marriageDate: Date = Date()
+  
+  var marriageStatus: MarriageStatus? {
+    guard let marriageDate = currentUser?.marriageDate else { return nil}
+    
+    let dDay = Date().calculateDDay(with: marriageDate)
+    
+    if dDay <= 0 {
+      return .married(-dDay + 1)
+    } else if dDay == 0 {
+      return .dday
+    } else {
+      return .notMarried(dDay)
+    }
+  }
   
   private var cancellables = Set<AnyCancellable>()
   
   init() {
     getUsers()
-    updateDayStatus()
+//    updateDayStatus()
   }
   
   func getUsers() {
@@ -64,17 +78,17 @@ final class ProfileMenuViewModel: ObservableObject {
     try UserManager.shared.updateMarriageDate(userId: myId, date: marriageDate)
   }
   
-  private func updateDayStatus() {
-    guard let marriageDate = currentUser?.marriageDate else { return }
-    
-    let dDay = Date().calculateDDay(with: marriageDate)
-    
-    if dDay <= 0 {
-      marriageStatus = .married(-dDay + 1)
-    } else if dDay == 0 {
-      marriageStatus = .dday
-    } else {
-      marriageStatus = .notMarried(dDay)
-    }
-  }
+//  private func updateDayStatus() {
+//    guard let marriageDate = currentUser?.marriageDate else { return }
+//    
+//    let dDay = Date().calculateDDay(with: marriageDate)
+//    
+//    if dDay <= 0 {
+//      marriageStatus = .married(-dDay + 1)
+//    } else if dDay == 0 {
+//      marriageStatus = .dday
+//    } else {
+//      marriageStatus = .notMarried(dDay)
+//    }
+//  }
 }

--- a/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuViewModel.swift
@@ -21,6 +21,10 @@ final class ProfileMenuViewModel: ObservableObject {
   @Published var nameChangeTextfield = ""
   @Published var marriageDate: Date = Date()
   
+  var isSignedIn: Bool {
+    currentUser != nil
+  }
+  
   var marriageStatus: MarriageStatus? {
     guard let marriageDate = currentUser?.marriageDate else { return nil}
     

--- a/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuViewModel.swift
@@ -39,13 +39,9 @@ final class ProfileMenuViewModel: ObservableObject {
   
   init() {
     getUsers()
-//    updateDayStatus()
   }
   
   func getUsers() {
-//    self.currentUser = UserManager.shared.currentUser
-//    self.fianceUser = UserManager.shared.fianceUser
-    
     UserManager.shared.$currentUser
       .sink { [weak self] user in
         self?.currentUser = user
@@ -76,19 +72,6 @@ final class ProfileMenuViewModel: ObservableObject {
   func updateMyMarriageDate() throws {
     guard let myId = currentUser?.userId else { return }
     try UserManager.shared.updateMarriageDate(userId: myId, date: marriageDate)
+    showCalendarSheet = false
   }
-  
-//  private func updateDayStatus() {
-//    guard let marriageDate = currentUser?.marriageDate else { return }
-//    
-//    let dDay = Date().calculateDDay(with: marriageDate)
-//    
-//    if dDay <= 0 {
-//      marriageStatus = .married(-dDay + 1)
-//    } else if dDay == 0 {
-//      marriageStatus = .dday
-//    } else {
-//      marriageStatus = .notMarried(dDay)
-//    }
-//  }
 }

--- a/ABloom/ABloom/Presentation/Main/QnAList/QnAListViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/QnAList/QnAListViewModel.swift
@@ -34,6 +34,7 @@ final class QnAListViewModel: ObservableObject {
   
   func fetchDataAfterSignIn() async {
     try? await UserManager.shared.fetchCurrentUser()
+    try? await UserManager.shared.fetchFianceUser()
     viewState = .isProgress
     fetchData()
   }

--- a/ABloom/ABloom/Presentation/SignUp/SignUpViewModel.swift
+++ b/ABloom/ABloom/Presentation/SignUp/SignUpViewModel.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@MainActor
 final class SignUpViewModel: ObservableObject {
   @Published var nowStep: SignUpStep = .step1
   @Published var selectedSex: UserSexType = .none


### PR DESCRIPTION
#### close #270

### ✏️ 개요
회원가입과 프로필 메뉴에서 입출력 동작이 있을 경우 데이터를 동기화 할 수 있는 로직을 추가하였습니다.

### 💻 작업 사항
- Combine을 이용하여 Model과 ViewModel 간의 데이터를 동기화할 수 있도록 구현하였습니다.
- 회원가입, 이름 및 결혼 예정일 수정, 연결관리, 회원탈퇴, 로그아웃의 동작이 수행될 때 Model의 데이터가 최신화 될 수 있도록 각 메서드에 fetch 동작을 추가하였습니다.

### 📄 리뷰 노트
- UserManager, ConnectionManager의 CUD 동작에 대해, 마무리로 데이터를 동기화 시키는 작업이 있는지 확인해주세요.
- ViewModel의 데이터가 동기화 될 수 있도록 sink 동작 메서드가 묶여있는지 확인하시면 됩니다.