### PR TITLE
[Feat/#279] Answer Data에 대한 Snapshot Listener 구현

### DIFF
--- a/ABloom/ABloom/ABloomApp.swift
+++ b/ABloom/ABloom/ABloomApp.swift
@@ -20,8 +20,8 @@ struct ABloomApp: App {
       try? await StaticQuestionManager.shared.fetchStaticQuestions()
       StaticQuestionManager.shared.fetchFilterQuestions()
       try? await EssentialQuestionManager.shared.fetchEssentialCollections()
-      try? await AnswerManager.shared.fetchMyAnswers()
-      try? await AnswerManager.shared.fetchFianceAnswers()
+      AnswerManager.shared.addSnapshotListenerForMyAnswer()
+      AnswerManager.shared.addSnapshotListenerForFianceAnswer()
     }
     
     UIView.appearance(whenContainedInInstancesOf: [UIAlertController.self]).tintColor = UIColor(named: "Purple 600")

--- a/ABloom/ABloom/Firebase/Firestore/AnswerManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/AnswerManager.swift
@@ -37,6 +37,25 @@ final class AnswerManager: ObservableObject {
   }
   
   // MARK: Retrieve
+  func addSnapshotListenerForMyAnswer() {
+    guard let currentUserId = UserManager.shared.currentUser?.userId else { return }
+    userAnswerCollection(userId: currentUserId).addSnapshotListener { querySnapshot, error in
+      guard let document = querySnapshot?.documents else { return }
+      
+      self.myAnswers = document.compactMap { try? $0.data(as: DBAnswer.self) }
+    }
+  }
+  
+  func addSnapshotListenerForFianceAnswer() {
+    guard let fianceId = UserManager.shared.currentUser?.fiance else { return }
+    
+    userAnswerCollection(userId: fianceId).addSnapshotListener { querySnapshot, error in
+      guard let document = querySnapshot?.documents else { return }
+      
+      self.fianceAnswers = document.compactMap { try? $0.data(as: DBAnswer.self) }
+    }
+  }
+  
   func fetchMyAnswers() async throws {
     guard let currentUserId = UserManager.shared.currentUser?.userId else { return }
     

--- a/ABloom/ABloom/Firebase/Firestore/ConnectionManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/ConnectionManager.swift
@@ -51,6 +51,8 @@ final class ConnectionManager {
     try await connectionUpdate(userId: currentUser.userId, targetId: targetUserId)
     try await UserManager.shared.fetchCurrentUser()
     try await UserManager.shared.fetchFianceUser()
+    AnswerManager.shared.addSnapshotListenerForMyAnswer()
+    AnswerManager.shared.addSnapshotListenerForFianceAnswer()
   }
   
   private func connectionUpdate(userId: String, targetId: String) async throws {

--- a/ABloom/ABloom/Presentation/Main/Menu/Connection/ConnectionViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/Menu/Connection/ConnectionViewModel.swift
@@ -33,7 +33,7 @@ final class ConnectionViewModel: ObservableObject {
   func connectUser() {
     Task {
       do {
-        try await ConnectionManager.shared.connectFiance(connectionCode: self.inputText)
+        try await UserManager.shared.connectFiance(connectionCode: self.inputText)
         getUsers()
       } catch let error as ConnectionError {
         self.errorMessage = error.errorMessage()

--- a/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuView.swift
+++ b/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuView.swift
@@ -104,6 +104,7 @@ struct ProfileMenuView: View {
           }
         } label: {
           Text("완료")
+            .customFont(.headlineB)
         }
       }
       .tint(.purple700)


### PR DESCRIPTION
#### close #279 

### ✏️ 개요
Snapshot Listener를 이용하여 응답을 실시간으로 가져올 수 있는 기능을 구현하였습니다.

### 💻 작업 사항
- addSnapshotListenerForMyAnswer() 함수 추가
- addSnapshotListenerForFianceAnswer() 함수 추가


### 📄 리뷰 노트
- Snapshot Listener를 통해 데이터베이스 상 변화가 있을 시 변경을 바로 가져올 수 있도록 하였습니다.
- 아직 라딘의 QnA View가 머지 되지 않아서, 뷰의 변화는 확인하지 못했지만, 로그상으로 확인 했을 때 잘 되는 것을 확인했습니다.
- 라딘은 Combine을 이용하여 데이터를 뷰 모델로 가져오는 코드를 구현하면 될 것 같습니다. @JINi0S 

### 📱결과 화면(optional)
<img width="686" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/77708819/346448cb-4387-4bbd-8c5c-c509201ed971">

