### PR TITLE
[Feat/#276] 문답확인뷰 연결/작성 시트 띄우기

### DIFF
--- a/ABloom/ABloom/Presentation/Main/CheckAnswer/CheckAnswerView.swift
+++ b/ABloom/ABloom/Presentation/Main/CheckAnswer/CheckAnswerView.swift
@@ -30,8 +30,10 @@ struct CheckAnswerView: View {
         .multilineTextAlignment(.leading)
       } else {
         ProgressView()
+          .frame(maxHeight: .infinity)
       }
     }
+    .scrollIndicators(.hidden)
     .padding(.horizontal, 20)
     .customNavigationBar {
       Text("우리의 문답")
@@ -63,7 +65,7 @@ struct CheckAnswerView: View {
 extension CheckAnswerView {
   private var questionArea: some View {
     HStack {
-      VStack(alignment: .leading, spacing: 6) {
+      VStack(alignment: .leading, spacing: 12) {
         Text(question.content.useNonBreakingSpace())
           .customFont(.headlineB)
         Text(checkAnswerVM.recentDate.formatToYMD())
@@ -76,27 +78,50 @@ extension CheckAnswerView {
   }
   
   private var myAnswerArea: some View {
-    VStack(alignment: .leading, spacing: 6) {
-      Text("\(checkAnswerVM.currentUserName)님의 대답")
-        .customFont(.calloutB)
-      Text(checkAnswerVM.currentUserAnswerContent.useNonBreakingSpace())
-        .customFont(.footnoteR)
-        .foregroundStyle(.gray500)
+    HStack {
+      VStack(alignment: .leading, spacing: 12) {
+        Text("\(checkAnswerVM.currentUserName)님의 대답")
+          .customFont(.calloutB)
+        Text(checkAnswerVM.currentUserAnswerContent.useNonBreakingSpace())
+          .customFont(.footnoteR)
+          .foregroundStyle(.gray500)
+        
+        HStack {
+          Spacer()
+          if checkAnswerVM.currentUserAnswer == nil {
+            buttonView(type: .write)
+          }
+        }
+        .padding(.top, -6)
+      }
+      Spacer(minLength: 0)
     }
   }
   
   private var fianceAnswerArea: some View {
-    VStack(alignment: .leading, spacing: 6) {
-      Text("\(checkAnswerVM.fianceName)님의 대답")
-        .customFont(.calloutB)
-      Text(checkAnswerVM.fianceAnswerContent.useNonBreakingSpace())
-        .customFont(.footnoteR)
-        .foregroundStyle(.gray500)
+    HStack {
+      VStack(alignment: .leading, spacing: 12) {
+        Text("\(checkAnswerVM.fianceName)님의 대답")
+          .customFont(.calloutB)
+        Text(checkAnswerVM.fianceAnswerContent.useNonBreakingSpace())
+          .customFont(.footnoteR)
+          .foregroundStyle(.gray500)
+        
+        HStack {
+          Spacer()
+          if checkAnswerVM.fianceUser == nil {
+            buttonView(type: .connect)
+          }
+        }
+        .padding(.top, -6)
+      }
+      Spacer(minLength: 0)
     }
+    
   }
   
   private var reactionArea: some View {
-    VStack(alignment: .leading, spacing: 6) {
+    VStack(alignment: .leading, spacing: 12) {
       Text("우리의 반응")
         .customFont(.calloutB)
       Text("둘 다 답변을 작성하면 우리만의 반응을 추가할 수 있어요.")
@@ -136,6 +161,23 @@ extension CheckAnswerView {
         }.disabled(!checkAnswerVM.isAnswersDone)
       }
       .foregroundStyle(.gray300)
+    }
+  }
+  
+  private func buttonView(type: SheetType) -> some View {
+    Button {
+      checkAnswerVM.showSheetType = type
+      checkAnswerVM.showSheet = true
+    } label: {
+      Text(type.rawValue)
+        .customFont(.footnoteB)
+        .foregroundStyle(.gray500)
+    }
+    .sheet(isPresented: $checkAnswerVM.showSheet) {
+      switch checkAnswerVM.showSheetType {
+      case .connect: ConnectionView()
+      case .write: WriteAnswerView(isSheetOn: $checkAnswerVM.showSheet, question: checkAnswerVM.dbQuestion)
+      }
     }
   }
 }

--- a/ABloom/ABloom/Presentation/Main/CheckAnswer/CheckAnswerViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/CheckAnswer/CheckAnswerViewModel.swift
@@ -7,6 +7,11 @@
 
 import Foundation
 
+enum SheetType: String {
+  case connect = "연결하기 >"
+  case write = "작성하기 >"
+}
+
 @MainActor
 final class CheckAnswerViewModel: ObservableObject {
   var dbQuestion: DBStaticQuestion = DBStaticQuestion(questionID: 1, category: "", content: "")
@@ -25,6 +30,9 @@ final class CheckAnswerViewModel: ObservableObject {
   
   @Published var recentDate: Date = .distantPast
     
+  @Published var showSheet: Bool = false
+  @Published var showSheetType: SheetType = .connect
+  
   @Published var showSelectReactionView: Bool = false
   @Published var selectedReaction: ReactionStatus = .noReact(.wait)
   


### PR DESCRIPTION
#### close #276 

### ✏️ 개요
문답확인뷰에서 연결/작성시트 보여주기

### 💻 작업 사항
- [x] 문답확인뷰에서 연결/작성시트 보여주기
- [x] 문답확인뷰 레이아웃 수정

### 📄 리뷰 노트
작성한 뒤 새로 데이터를 불러오지 않아, 앱을 새로 켜야합니다.

### 📱결과 화면(optional)
![Simulator Screen Recording - iPhone 15 - 2023-11-27 at 01 25 16](https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/100195563/7a8391a9-0011-409a-a8c9-65ace2df87c5)
