### PR TITLE
[Release] noti 앱 내 모달해결

### DIFF
--- a/ABloom/ABloom/AppDelegate.swift
+++ b/ABloom/ABloom/AppDelegate.swift
@@ -119,7 +119,6 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     
     let userInfo = notification.request.content.userInfo
     
-    handleNotificationPayload(userInfo)
     
     completionHandler([[.banner, .badge, .sound]])
   }


### PR DESCRIPTION
### ✏️ 개요
알림 클릭 시에만 모달이 뜨도록 하고, 앱을 사용중에는 반응하지 않도록 수정