### PR TITLE
[Bug/#289] QA 반영

### DIFF
--- a/ABloom/ABloom.xcodeproj/project.pbxproj
+++ b/ABloom/ABloom.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		3DD485F02B0D9E9E00AF5E02 /* ConnectedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DD485EF2B0D9E9E00AF5E02 /* ConnectedView.swift */; };
 		3DD485F22B0DAAB300AF5E02 /* ConnectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DD485F12B0DAAB300AF5E02 /* ConnectionViewModel.swift */; };
 		3DD485F42B0DAC5800AF5E02 /* ConnectingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DD485F32B0DAC5800AF5E02 /* ConnectingView.swift */; };
+		3DD4860F2B14910200AF5E02 /* Kakao-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3DD4860E2B14910200AF5E02 /* Kakao-Info.plist */; };
 		3DE945042AFA96C900CF7E33 /* ReactionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE945032AFA96C900CF7E33 /* ReactionType.swift */; };
 		3DF31AE72B0453DF00F0EA4E /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF31AE62B0453DF00F0EA4E /* SignInView.swift */; };
 		3DF31AE92B0453E700F0EA4E /* SignUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF31AE82B0453E700F0EA4E /* SignUpView.swift */; };
@@ -87,15 +88,14 @@
 		607DA2162AEFE900005AE11C /* ConnectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607DA2152AEFE900005AE11C /* ConnectionManager.swift */; };
 		607DA2182AF0B07D005AE11C /* Ex+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607DA2172AF0B07D005AE11C /* Ex+Date.swift */; };
 		6086BAA92AF130A800E2DC3A /* DBEssentialQuestionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6086BAA82AF130A800E2DC3A /* DBEssentialQuestionModel.swift */; };
+		60A134642B103593002E0A9F /* ReactionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60A134632B103593002E0A9F /* ReactionStatus.swift */; };
 		60EEC2ED2B1223B10049DAFD /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 60EEC2EC2B1223B10049DAFD /* KakaoSDK */; };
 		60EEC2EF2B1223B10049DAFD /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 60EEC2EE2B1223B10049DAFD /* KakaoSDKAuth */; };
 		60EEC2F12B1223B10049DAFD /* KakaoSDKCert in Frameworks */ = {isa = PBXBuildFile; productRef = 60EEC2F02B1223B10049DAFD /* KakaoSDKCert */; };
 		60EEC2F32B1223B10049DAFD /* KakaoSDKCertCore in Frameworks */ = {isa = PBXBuildFile; productRef = 60EEC2F22B1223B10049DAFD /* KakaoSDKCertCore */; };
 		60EEC2F52B1223B10049DAFD /* KakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 60EEC2F42B1223B10049DAFD /* KakaoSDKCommon */; };
 		60EEC2F72B1231560049DAFD /* SignInKakaoHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60EEC2F62B1231560049DAFD /* SignInKakaoHelper.swift */; };
-		60EEC2FA2B123A700049DAFD /* Kakao-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 60EEC2F92B123A700049DAFD /* Kakao-Info.plist */; };
 		60EEC2FC2B125D210049DAFD /* Ex+Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60EEC2FB2B125D210049DAFD /* Ex+Bundle.swift */; };
-		60A134642B103593002E0A9F /* ReactionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60A134632B103593002E0A9F /* ReactionStatus.swift */; };
 		AE02ABED2B0C8A08004648F9 /* FLAnimatedImage in Frameworks */ = {isa = PBXBuildFile; productRef = AE02ABEC2B0C8A08004648F9 /* FLAnimatedImage */; };
 		AE1AE9FB2AE51BF00010089F /* QnAListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1AE9FA2AE51BF00010089F /* QnAListItem.swift */; };
 		AE2BB5F42AD650680003CD85 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = AE2BB5F32AD650680003CD85 /* .swiftlint.yml */; };
@@ -165,6 +165,7 @@
 		3DD485EF2B0D9E9E00AF5E02 /* ConnectedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedView.swift; sourceTree = "<group>"; };
 		3DD485F12B0DAAB300AF5E02 /* ConnectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionViewModel.swift; sourceTree = "<group>"; };
 		3DD485F32B0DAC5800AF5E02 /* ConnectingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectingView.swift; sourceTree = "<group>"; };
+		3DD4860E2B14910200AF5E02 /* Kakao-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Kakao-Info.plist"; sourceTree = "<group>"; };
 		3DE945032AFA96C900CF7E33 /* ReactionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactionType.swift; sourceTree = "<group>"; };
 		3DF31AE62B0453DF00F0EA4E /* SignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInView.swift; sourceTree = "<group>"; };
 		3DF31AE82B0453E700F0EA4E /* SignUpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpView.swift; sourceTree = "<group>"; };
@@ -207,7 +208,6 @@
 		60A134632B103593002E0A9F /* ReactionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactionStatus.swift; sourceTree = "<group>"; };
 		60E05FAF2AFBB66200AC6AE8 /* TipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TipView.swift; sourceTree = "<group>"; };
 		60EEC2F62B1231560049DAFD /* SignInKakaoHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInKakaoHelper.swift; sourceTree = "<group>"; };
-		60EEC2F92B123A700049DAFD /* Kakao-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Kakao-Info.plist"; sourceTree = "<group>"; };
 		60EEC2FB2B125D210049DAFD /* Ex+Bundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ex+Bundle.swift"; sourceTree = "<group>"; };
 		AE1AE9F82AE50BBC0010089F /* QuestionMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionMainView.swift; sourceTree = "<group>"; };
 		AE1AE9FA2AE51BF00010089F /* QnAListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QnAListItem.swift; sourceTree = "<group>"; };
@@ -713,7 +713,7 @@
 				3DB6A5B52AE1278D00C1369F /* ABloom.entitlements */,
 				AEC44E032AF628DF0021156E /* Launch Screen.storyboard */,
 				AE8D3C5D2ADE1A22009899A7 /* Info.plist */,
-				60EEC2F92B123A700049DAFD /* Kakao-Info.plist */,
+				3DD4860E2B14910200AF5E02 /* Kakao-Info.plist */,
 				3D4412792AEAB34000FD5A51 /* GoogleService-Info.plist */,
 				AE7EE4E02AD6409000E0A573 /* ABloomApp.swift */,
 				AE5EB9FA2AF1396C0074F361 /* AppDelegate.swift */,
@@ -902,7 +902,7 @@
 				3D44127A2AEAB34000FD5A51 /* GoogleService-Info.plist in Resources */,
 				AEBDE5692B06FC46005711BF /* NanumSquareNeo-dEb.ttf in Resources */,
 				AE2BB5F42AD650680003CD85 /* .swiftlint.yml in Resources */,
-				60EEC2FA2B123A700049DAFD /* Kakao-Info.plist in Resources */,
+				3DD4860F2B14910200AF5E02 /* Kakao-Info.plist in Resources */,
 				AE7EE4E82AD6409100E0A573 /* Preview Assets.xcassets in Resources */,
 				AEBDE56B2B06FC46005711BF /* NanumSquareNeo-bRg.ttf in Resources */,
 				3D44126B2AE6246100FD5A51 /* Assets.xcassets in Resources */,
@@ -1173,7 +1173,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.abloom.ABloom;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1217,7 +1217,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.abloom.ABloom;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/ABloom/ABloom/Firebase/Authentication/AuthenticationManager.swift
+++ b/ABloom/ABloom/Firebase/Authentication/AuthenticationManager.swift
@@ -76,6 +76,7 @@ final class AuthenticationManager {
     SignInKakaoHelper().kakaoSignOut()
     
     Task {
+      await AnswerManager.shared.disconnectListener()
       try? await UserManager.shared.fetchCurrentUser()
       try? await UserManager.shared.fetchFianceUser()
     }

--- a/ABloom/ABloom/Firebase/Firestore/AnswerManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/AnswerManager.swift
@@ -16,6 +16,9 @@ final class AnswerManager: ObservableObject {
   
   static let shared = AnswerManager()
   
+  var myAnswersListener: ListenerRegistration?
+  var fianceAnswersListener: ListenerRegistration?
+  
   private let userCollection = Firestore.firestore().collection("users")
   
   private func userDocument(userId: String) -> DocumentReference {
@@ -86,6 +89,14 @@ final class AnswerManager: ObservableObject {
     let data: [String: Any] = [DBAnswer.CodingKeys.reaction.rawValue:reaction.rawValue]
     
     userAnswerCollection(userId: userId).document(answerId).updateData(data)
+  }
+  
+  // MARK: Disconnect
+  func disconnectListener() {
+    self.myAnswersListener?.remove()
+    self.fianceAnswersListener?.remove()
+    self.myAnswers = []
+    self.fianceAnswers = []
   }
   
   // MARK: Not Use

--- a/ABloom/ABloom/Firebase/Firestore/UserManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/UserManager.swift
@@ -133,13 +133,6 @@ final class UserManager: ObservableObject {
     
     let data: [String: Any?] = [DBUser.CodingKeys.fiance.rawValue: nil]
     try await userDocument(userId: fiance).updateData(data as [AnyHashable: Any])
-    
-    AnswerManager.shared.disconnectListener()
-    
-    Task {
-      try? await fetchCurrentUser()
-      try? await fetchFianceUser()
-    }
   }
   
   private func deleteSubCollection(userId: String) async throws {

--- a/ABloom/ABloom/Firebase/Firestore/UserManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/UserManager.swift
@@ -134,6 +134,8 @@ final class UserManager: ObservableObject {
     let data: [String: Any?] = [DBUser.CodingKeys.fiance.rawValue: nil]
     try await userDocument(userId: fiance).updateData(data as [AnyHashable: Any])
     
+    AnswerManager.shared.disconnectListener()
+    
     Task {
       try? await fetchCurrentUser()
       try? await fetchFianceUser()

--- a/ABloom/ABloom/Firebase/Firestore/UserManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/UserManager.swift
@@ -32,6 +32,8 @@ final class UserManager: ObservableObject {
     try userDocument(userId: user.userId).setData(from: user, merge: false)
     Task {
       try? await fetchCurrentUser()
+      AnswerManager.shared.addSnapshotListenerForMyAnswer()
+      AnswerManager.shared.addSnapshotListenerForFianceAnswer()
     }
   }
   

--- a/ABloom/ABloom/Presentation/Main/CreateAnswer/CategoryWaypoint/CategoryWaypointView.swift
+++ b/ABloom/ABloom/Presentation/Main/CreateAnswer/CategoryWaypoint/CategoryWaypointView.swift
@@ -45,6 +45,7 @@ struct CategoryWaypointView: View {
       
       .task {
         try? await categoryWayVM.loadRecommendedQuestion()
+        categoryWayVM.checkLogin()
       }
       
       .customNavigationBar {

--- a/ABloom/ABloom/Presentation/Main/CreateAnswer/CategoryWaypoint/CategoryWaypointViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/CreateAnswer/CategoryWaypoint/CategoryWaypointViewModel.swift
@@ -42,6 +42,14 @@ final class CategoryWaypointViewModel: ObservableObject {
     self.fetchInformation()
   }
   
+  func checkLogin() {
+    do {
+      try AuthenticationManager.shared.getAuthenticatedUser()
+    } catch {
+      questionStatus = .notLoggedIn
+    }
+  }
+  
   private func fetchInformation() {
     
     if let essentials = EssentialQuestionManager.shared.essentialQuestions {

--- a/ABloom/ABloom/Presentation/Main/Menu/Connection/ConnectingView.swift
+++ b/ABloom/ABloom/Presentation/Main/Menu/Connection/ConnectingView.swift
@@ -34,6 +34,8 @@ struct ConnectingView: View {
     .padding(.top, 39)
     .padding(.horizontal, 20)
     
+    .onAppear(perform: UIApplication.shared.hideKeyboard)
+    
     .alert("연결에 실패했어요", isPresented: $vm.showErrorAlert, actions: {
       Button("확인") {
         vm.showErrorAlert = false

--- a/ABloom/ABloom/Presentation/Main/Menu/Connection/ConnectingView.swift
+++ b/ABloom/ABloom/Presentation/Main/Menu/Connection/ConnectingView.swift
@@ -15,21 +15,31 @@ struct ConnectingView: View {
   @State var showToast = false
   
   var body: some View {
-    VStack(alignment: .leading) {
-      Text(explainText)
-        .customFont(.caption1R)
-        .foregroundStyle(.gray600)
-        .padding(.bottom, 40)
+    ZStack {
+      VStack(alignment: .leading) {
+        Text(explainText)
+          .customFont(.caption1R)
+          .foregroundStyle(.gray600)
+          .padding(.bottom, 40)
+        
+        myCodeSection
+          .padding(.bottom, 24)
+        
+        fianceCodeSection
+        
+        Spacer()
+        
+        connectButton
+          .padding(.bottom, 20)
+      }
       
-      myCodeSection
-        .padding(.bottom, 24)
-      
-      fianceCodeSection
-      
-      Spacer()
-      
-      connectButton
-        .padding(.bottom, 20)
+      VStack {
+        Spacer()
+        if showToast {
+          ToastView(message: "코드가 복사되었습니다")
+            .padding(.bottom, 100)
+        }
+      }
     }
     .padding(.top, 39)
     .padding(.horizontal, 20)
@@ -82,7 +92,7 @@ extension ConnectingView {
     } label: {
       PurpleTextButton(title: "연결하기", isDisable: !vm.isTargetCodeInputVaild)
     }
-
+    
   }
   
   private func copyClipboard() {

--- a/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuView.swift
+++ b/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuView.swift
@@ -55,59 +55,18 @@ struct ProfileMenuView: View {
     
     .ignoresSafeArea(.all, edges: .bottom)
     
-    .confirmationDialog("", isPresented: $vm.showActionSheet, titleVisibility: .hidden) {
-      Button("이름 변경하기") {
-        vm.showNameChangeAlert = true
+    .alert("로그인이 필요한 서비스예요.", isPresented: $vm.showNotLoginAlert) {
+      Button("취소", role: .cancel) {
+        vm.showNotLoginAlert = false
       }
       
-      Button("결혼예정일 수정하기") {
-        vm.showCalendarSheet = true
-      }
-    }
-    
-    // 이름 수정
-    .alert("이름 변경하기", isPresented: $vm.showNameChangeAlert) {
-      TextField(text: $vm.nameChangeTextfield) {
-        Text("홍길동")
-      }
-      
-      Button {
-        vm.showNameChangeAlert = false
-      } label: {
-        Text("취소")
-      }
-      
-      Button("확인") {
-        Task {
-          try? vm.updateMyName()
-          try? await vm.renewInfo()
+      Button("로그인") {
+        vm.showNotLoginAlert = false
+        showProfileMenuSheet = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+          activeSheet.kind = .signIn
         }
       }
-    } message: {
-      Text("변경할 이름을 입력해주세요.")
-    }
-    
-    // 결혼 일자 수정
-    .sheet(isPresented: $vm.showCalendarSheet) {
-      VStack {
-        DatePicker("", selection: $vm.marriageDate, displayedComponents: .date)
-          .datePickerStyle(.graphical)
-          .frame(width: 320)
-          .labelsHidden()
-          .presentationDetents([.medium])
-        
-        Button {
-          Task {
-            try? vm.updateMyMarriageDate()
-            try? await vm.renewInfo()
-            vm.showActionSheet = false
-          }
-        } label: {
-          Text("완료")
-            .customFont(.headlineB)
-        }
-      }
-      .tint(.purple700)
     }
   }
 }
@@ -192,18 +151,85 @@ extension ProfileMenuView {
         .customFont(.headlineB)
       
       Button {
-        vm.showActionSheet = true
+        if vm.isSignedIn {
+          vm.showActionSheet = true
+        } else {
+          vm.showNotLoginAlert = true
+        }
       } label: {
         listRowLabel(title: "내 정보 수정하기")
       }
       
-      NavigationLink {
-        ConnectionView()
-      } label: {
-        listRowLabel(title: "상대방과 연결 관리", isIssue: (vm.currentUser?.fiance) == nil)
+      if vm.isSignedIn {
+        NavigationLink {
+          ConnectionView()
+        } label: {
+          listRowLabel(title: "상대방과 연결 관리", isIssue: (vm.currentUser?.fiance) == nil)
+        }
+      } else {
+        Button {
+          vm.showNotLoginAlert = true
+        } label: {
+          listRowLabel(title: "상대방과 연결 관리")
+        }
       }
     }
     .padding(.horizontal, 20)
+    
+    .confirmationDialog("", isPresented: $vm.showActionSheet, titleVisibility: .hidden) {
+      Button("이름 변경하기") {
+        vm.showNameChangeAlert = true
+      }
+      
+      Button("결혼예정일 수정하기") {
+        vm.showCalendarSheet = true
+      }
+    }
+    
+    // 이름 수정
+    .alert("이름 변경하기", isPresented: $vm.showNameChangeAlert) {
+      TextField(text: $vm.nameChangeTextfield) {
+        Text("홍길동")
+      }
+      
+      Button {
+        vm.showNameChangeAlert = false
+      } label: {
+        Text("취소")
+      }
+      
+      Button("확인") {
+        Task {
+          try? vm.updateMyName()
+          try? await vm.renewInfo()
+        }
+      }
+    } message: {
+      Text("변경할 이름을 입력해주세요.")
+    }
+    
+    // 결혼 일자 수정
+    .sheet(isPresented: $vm.showCalendarSheet) {
+      VStack {
+        DatePicker("", selection: $vm.marriageDate, displayedComponents: .date)
+          .datePickerStyle(.graphical)
+          .frame(width: 320)
+          .labelsHidden()
+          .presentationDetents([.medium])
+        
+        Button {
+          Task {
+            try? vm.updateMyMarriageDate()
+            try? await vm.renewInfo()
+            vm.showActionSheet = false
+          }
+        } label: {
+          Text("완료")
+            .customFont(.headlineB)
+        }
+      }
+      .tint(.purple700)
+    }
   }
   
   private var serviceUse: some View {

--- a/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuView.swift
+++ b/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuView.swift
@@ -239,9 +239,9 @@ extension ProfileMenuView {
         .customFont(.headlineB)
       
       NavigationLink {
-        EmbedWebView(viewTitle: "문답 연구소", urlString: ServiceWebURL.questionLab.rawValue, type: .navigation, showSheet: .constant(true), checkContract: .constant(true))
+        EmbedWebView(viewTitle: "질문 제작소", urlString: ServiceWebURL.questionLab.rawValue, type: .navigation, showSheet: .constant(true), checkContract: .constant(true))
       } label: {
-        listRowLabel(title: "문답 연구소")
+        listRowLabel(title: "질문 제작소")
       }
       
       NavigationLink {

--- a/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuView.swift
+++ b/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuView.swift
@@ -303,6 +303,7 @@ extension ProfileMenuView {
       
       Button("로그아웃", role: .destructive) {
         try? vm.signOut()
+        showProfileMenuSheet = false
       }
     }, message: {
       Text("로그아웃하더라도 데이터는 보관되니\n안심하고 로그아웃하셔도 돼요.")

--- a/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuView.swift
+++ b/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuView.swift
@@ -283,15 +283,18 @@ extension ProfileMenuView {
         vm.showSignOutAlert = true
       } label: {
         listRowLabel(title: "로그아웃")
+          .opacity(vm.isSignedIn ? 1.0 : 0.5)
       }
       
       NavigationLink {
         WithdrawalMembershipView(showProfileMenuSheet: $showProfileMenuSheet)
       } label: {
         listRowLabel(title: "회원탈퇴")
+          .opacity(vm.isSignedIn ? 1.0 : 0.5)
       }
     }
     .padding(.horizontal, 20)
+    .disabled(!vm.isSignedIn)
     
     .alert("로그아웃할까요?", isPresented: $vm.showSignOutAlert, actions: {
       Button("취소", role: .cancel) {

--- a/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuView.swift
+++ b/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuView.swift
@@ -201,7 +201,7 @@ extension ProfileMenuView {
       Button("확인") {
         Task {
           try? vm.updateMyName()
-          try? await vm.renewInfo()
+          await vm.renewInfo()
         }
       }
     } message: {
@@ -220,7 +220,7 @@ extension ProfileMenuView {
         Button {
           Task {
             try? vm.updateMyMarriageDate()
-            try? await vm.renewInfo()
+            await vm.renewInfo()
             vm.showActionSheet = false
           }
         } label: {

--- a/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuViewModel.swift
@@ -70,8 +70,6 @@ final class ProfileMenuViewModel: ObservableObject {
       try AuthenticationManager.shared.signOut()
       await renewInfo()
       AnswerManager.shared.disconnectListener()
-      try await UserManager.shared.fetchCurrentUser()
-      try await UserManager.shared.fetchFianceUser()
     }
   }
   

--- a/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuViewModel.swift
@@ -69,7 +69,6 @@ final class ProfileMenuViewModel: ObservableObject {
     Task {
       try AuthenticationManager.shared.signOut()
       await renewInfo()
-      AnswerManager.shared.disconnectListener()
     }
   }
   

--- a/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuViewModel.swift
@@ -70,6 +70,8 @@ final class ProfileMenuViewModel: ObservableObject {
       try AuthenticationManager.shared.signOut()
       await renewInfo()
       AnswerManager.shared.disconnectListener()
+      try await UserManager.shared.fetchCurrentUser()
+      try await UserManager.shared.fetchFianceUser()
     }
   }
   

--- a/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuViewModel.swift
@@ -17,6 +17,7 @@ final class ProfileMenuViewModel: ObservableObject {
   @Published var showNameChangeAlert = false
   @Published var showCalendarSheet = false
   @Published var showSignOutAlert = false
+  @Published var showNotLoginAlert = false
   
   @Published var nameChangeTextfield = ""
   @Published var marriageDate: Date = Date()

--- a/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/Menu/ProfileMenu/ProfileMenuViewModel.swift
@@ -60,13 +60,17 @@ final class ProfileMenuViewModel: ObservableObject {
       .store(in: &cancellables)
   }
   
-  func renewInfo() async throws {
+  func renewInfo() async {
     try? await UserManager.shared.fetchCurrentUser()
-    getUsers()
+    try? await UserManager.shared.fetchFianceUser()
   }
   
   func signOut() throws {
-    try AuthenticationManager.shared.signOut()
+    Task {
+      try AuthenticationManager.shared.signOut()
+      await renewInfo()
+      AnswerManager.shared.disconnectListener()
+    }
   }
   
   func updateMyName() throws {

--- a/ABloom/ABloom/Presentation/Main/Menu/WithdrawalMembership/WithdrawalMembershipView.swift
+++ b/ABloom/ABloom/Presentation/Main/Menu/WithdrawalMembership/WithdrawalMembershipView.swift
@@ -83,6 +83,8 @@ struct WithdrawalMembershipView: View {
         }
         
         showProfileMenuSheet = false
+        
+        UserDefaults.standard.setValue(true, forKey: "_isFirstLaunching")
       }
     } message: {
       Text(alertMessage)


### PR DESCRIPTION
#### close #289

### ✏️ 개요
QA시 진행한 피드백을 수용하였습니다.

### 💻 작업 사항
- 미로그인 시, 내 정보 수정 및 상대방과 연결 기능을 사용할 수 없어야 한다.
- 미로그인 시, 회원탈퇴, 로그아웃 사용할 수 없어야 한다.
- 로그아웃 시, 홈 화면으로 돌아가야 한다.
- 로그아웃 시, QnA List가 초기화 되어야 한다.
- 로그아웃 시, 질문을 선택할 수 없어야 한다.
- 회원탈퇴 시, 상기 로그아웃 이슈와 동일하다.
- 회원탈퇴 시, 온보딩 화면으로 이동하여야 한다.
- 연결 관리 시, 연결 코드 입력 중 키보드를 숨길 수 있어야 한다.
- 연결 하기 뷰에서 복사 기능 수행 시, 토스트 메세지가 출력되어야 한다.
- 메뉴 뷰, 문답 연구소 → 질문 제작소 라이팅 수정