### PR TITLE
[Feat/#299] 문답리스트뷰 상대방없을 시 프로필 빨간 점 추가

### DIFF
--- a/ABloom/ABloom/Presentation/Main/QnAList/QnAListView.swift
+++ b/ABloom/ABloom/Presentation/Main/QnAList/QnAListView.swift
@@ -68,6 +68,13 @@ extension QnAListView {
         .scaledToFit()
         .clipShape(Circle())
         .frame(width: 32)
+        .overlay(alignment: .bottomTrailing) {
+          if let currentUser = qnaListVM.currentUser, currentUser.fiance == nil {
+              Circle()
+                .frame(width: 8)
+                .foregroundStyle(.red)
+            }
+        }
     }
     .sheet(isPresented: $qnaListVM.showProfileSheet) {
       NavigationStack {


### PR DESCRIPTION
#### close #299 

### ✏️ 개요
상대방과의 연결이 없을 시 문답리스트뷰의 프로필에서 빨간 점을 통해 알 수 있도록 합니다.

### 💻 작업 사항
문답리스트뷰 프로필에 빨간 점을 추가하였습니다.

### 📄 리뷰 노트
없씁니다.

### 📱결과 화면(optional)
<img src = "https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/100195563/dd2875b6-d3b6-4a30-970f-bc0611de4c82" width = "300"> 