### PR TITLE
[Feat/#303] TextField 영역확장 (Editor로 바꿈)

### DIFF
--- a/ABloom/ABloom/Presentation/Main/CreateAnswer/WriteAnswer/WriteAnswerView.swift
+++ b/ABloom/ABloom/Presentation/Main/CreateAnswer/WriteAnswer/WriteAnswerView.swift
@@ -15,13 +15,14 @@ struct WriteAnswerView: View {
   var question: DBStaticQuestion
   
   var body: some View {
-    VStack(alignment: .leading, spacing: 20) {
+    VStack(alignment: .leading, spacing: 15) {
       
       questionText
       
       ZStack(alignment: .top) {
         
         textField
+          .padding(.horizontal, -5)
         
         textNumCheck
           .position(x: UIScreen.main.bounds.size.width/2 - 20, y: UIScreen.main.bounds.size.height/3.5)
@@ -98,16 +99,19 @@ extension WriteAnswerView {
   }
   
   private var textField: some View {
-    TextField("", text: $writeAMV.ansText, axis: .vertical)
-      .placeholder(when: writeAMV.ansText.isEmpty, placeholder: {
-        Text("내 답변을 작성해보세요...")
-          .customFont(.calloutR)
-          .foregroundStyle(.gray400)
-      })
-      .customFont(.calloutR)
+    
+    TextEditor(text: $writeAMV.ansText)
+      .opacity(writeAMV.ansText.isEmpty ? 0.2 : 1.0)
+      .background(alignment: .topLeading) {
+        TextEditor(text: .constant(writeAMV.ansText.isEmpty ? "내 답변을 작성해보세요..." : ""))
+          .foregroundStyle(.gray500)
+      }
       .foregroundStyle(.gray500)
+      .accentColor(.biPurple)
+      .customFont(.calloutR)
       .multilineTextAlignment(.leading)
       .frame(maxWidth: .infinity)
+      .frame(maxHeight: UIScreen.main.bounds.size.height/3.5 - 10) 
       .onChange(of: writeAMV.ansText, perform: { new in
         writeAMV.checkTextCount()
       })


### PR DESCRIPTION
#### close #303

### ✏️ 개요
TextField 워드 카운트 위 영역 클릭 시 바로 작성할 수 있도록 영역 확장

### 💻 작업 사항
- TextField에서 TextEditor로 교체
- TextEditor는 내부 패딩이 존재하고, 이를 수정할 수 없어서, 다른 패딩 값 조율하여 맞춤
- TextEditor에 따로 placeholder를 주는 방법이 없어 background로 비치 (ZStack 과 background 방법이 있었는데, 내부패딩으로 인해 일반 Text로 할경우 임의로 패딩값 설정이 필요해서 background로 TextEditor를 추가하고 opacity로 처리함)
- placeholder를 위해 opacity 값을 추가하였음. 이에 따라, 텍스트 색상 더 찐한거로 변경하여 육안상 디자인 맞춤
- 커서 색상이 기본 파란색이라서 biPurple 색상으로 바꿈

### 📄 리뷰 노트
- 처음 클릭시에는 두번 탭하여야 버튼을 인식하는 듯 하고, 다음부터는 한번만 클릭해도 인식돼요.
- 카운트 영역 아래를 클릭시에는 키보드가 내려갑니다. (이전에는 텍스트 필드 영역 외부면 내려갔으나, 영역을 고정시켰기에 카운트 영역 아래 클릭해야 합니다.)
- opacity로 placeholder를 처리하여 처음 텍스트 입력할 때, 커서도 투명도가 있습니다.

### 📱결과 화면(optional)
https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/44897331/b7b3eb7e-e81c-4631-a911-30e8f4cc5baa

* 시뮬레이터에서 동작할 때는 키보드 관련 작업이 느리게 처리되지만, 클릭 상태 확인을 위해 위 영상 첨부
* 커서의 움직임으로 키보드 유무 확인 가능
