### PR TITLE
[Design/#306] scrollArea 늘리기

### DIFF
--- a/ABloom/ABloom/Presentation/Main/QnAList/QnAListView.swift
+++ b/ABloom/ABloom/Presentation/Main/QnAList/QnAListView.swift
@@ -103,7 +103,7 @@ extension QnAListView {
           .padding(.horizontal, 20)
         }
         
-        Spacer().frame(height: 30)
+        Spacer().frame(height: 110)
       }
     }
     .shadow(color: .black.opacity(0.08), radius: 16, x: 0, y: 0)


### PR DESCRIPTION
#### close #306

### ✏️ 개요
메인 화면에서 플러팅 버튼의 시야를 위해 스크롤 되는 영역 확장

### 💻 작업 사항
- 패딩 값 조절

### 📄 리뷰 노트
X

### 📱결과 화면(optional)
| 화면 |
|--------|
| ![Simulator Screenshot - iPhone 15 Pro - 2024-01-15 at 16 51 52](https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/44897331/79bac081-f662-4ae2-8723-8d66da6f0bbb) | 

### 📚 ETC(optional)