### PR TITLE
[Bug/#320] 회원가입 이름 입력창 줄어드는 버그 수정

### DIFF
--- a/ABloom/ABloom/Presentation/SignUp/SignUpContentView.swift
+++ b/ABloom/ABloom/Presentation/SignUp/SignUpContentView.swift
@@ -92,6 +92,7 @@ extension SignUpContentView {
           .customFont(.headlineR)
           .foregroundStyle(.gray500)
       }
+      .frame(height: 27)
       .customFont(.headlineR)
       .padding(.vertical, 20)
       .padding(.horizontal, 22)

--- a/ABloom/ABloom/Resources/Utilities/ReactionType.swift
+++ b/ABloom/ABloom/Resources/Utilities/ReactionType.swift
@@ -88,7 +88,7 @@ enum NoReactType: Reaction {
   var reactionContent: String {
     switch self {
     case .lock:
-      "잠겨 있어요"
+      "잠겨있어요"
     case .plus:
       ""
     case .wait:


### PR DESCRIPTION
#### close #320 

### ✏️ 개요
회원가입시 이름 입력하는 부분의 높이를 패딩으로 지정해두여 텍스트를 입력할 시 높이가 줄어드는 문제 해결

### 💻 작업 사항
- [x] 텍스트필드의 높이를 27로 고정
- [x] 반응 띄어쓰기 수정 

### 📄 리뷰 노트
확인해보니까 아래의 .lineSpacing(7)이 적용되어있는 부분 때문에 높이가 유동적인 것 같습니다.
customFont 메서드 변경없이 높이만 고정해두어도 문제는 해결되어 높이만 지정하는 방식으로 수정하였씀다-!

```swift
func customFont(_ fontStyle: Font) -> some View {
    self
      .font(fontStyle)
      .lineSpacing(7)
      .tracking(-0.4)
  }
``` 

### 📱결과 화면(optional)
![Simulator Screen Recording - iPhone 15 - 2024-02-12 at 22 38 06](https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/100195563/87281219-8772-4c03-b6cc-d6a00d8ce904)
