### PR TITLE
[Fix] HOT FIX - 애플 로그인 시 사용자 이름 요청 제거

### DIFF
--- a/ABloom/ABloom.xcodeproj/project.pbxproj
+++ b/ABloom/ABloom.xcodeproj/project.pbxproj
@@ -946,7 +946,7 @@
 				CODE_SIGN_ENTITLEMENTS = ABloom/ABloom.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_ASSET_PATHS = "\"ABloom/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = G7X65ZSJ3J;
@@ -990,7 +990,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_ASSET_PATHS = "\"ABloom/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = G7X65ZSJ3J;

--- a/ABloom/ABloom/Firebase/Authentication/AuthenticationManager.swift
+++ b/ABloom/ABloom/Firebase/Authentication/AuthenticationManager.swift
@@ -33,7 +33,7 @@ final class AuthenticationManager {
   ///   - AuthDataResultModel: 유저의 정보를 리턴합니다.
   @discardableResult
   func signInWithApple(tokens: SignInWithAppleResult) async throws -> AuthDataResultModel {
-    let credential = OAuthProvider.appleCredential(withIDToken: tokens.token, rawNonce: tokens.nonce, fullName: tokens.fullName)
+    let credential = OAuthProvider.appleCredential(withIDToken: tokens.token, rawNonce: tokens.nonce, fullName: nil)
     
     return try await signIn(credential: credential)
   }

--- a/ABloom/ABloom/Firebase/Authentication/SignInAppleHelper.swift
+++ b/ABloom/ABloom/Firebase/Authentication/SignInAppleHelper.swift
@@ -13,7 +13,6 @@ import SwiftUI
 struct SignInWithAppleResult {
   let token: String
   let nonce: String
-  let fullName: PersonNameComponents?
 }
 
 @MainActor
@@ -51,7 +50,7 @@ final class SignInAppleHelper: NSObject {
     
     let appleIDProvider = ASAuthorizationAppleIDProvider()
     let request = appleIDProvider.createRequest()
-    request.requestedScopes = [.fullName, .email] // 애플 로그인을 통해 제공 받을 부분은 이름입니다.
+    request.requestedScopes = [.email] // 애플 로그인을 통해 제공 받을 부분은 이름입니다.
     request.nonce = sha256(nonce)
     
     let authorizationController = ASAuthorizationController(authorizationRequests: [request])
@@ -108,7 +107,7 @@ extension SignInAppleHelper: ASAuthorizationControllerDelegate {
       return
     }
     
-    let tokens = SignInWithAppleResult(token: idTokenString, nonce: nonce, fullName: appleIDCredential.fullName)
+    let tokens = SignInWithAppleResult(token: idTokenString, nonce: nonce)
     
     completionHandler?(.success(tokens))
   }


### PR DESCRIPTION
### ✏️ 개요
애플 로그인 시 사용자 이름 요청 제거

cf. [Slack 쓰레드](https://theabloom.slack.com/archives/C06BG91V8GP/p1708093836296099)

### 💻 작업 사항
핫픽스 요청에 따른 애플 로그인 시 사용자 이름을 요청하는 부분을 삭제했습니다.

### 📄 리뷰 노트
회원가입 플로우 진행에 아무 문제 없었습니다.