### PR TITLE
[Design/#328] 만 14세 이상 확인 버튼 추가

### DIFF
--- a/ABloom/ABloom/Presentation/SignUp/SignUpContentView.swift
+++ b/ABloom/ABloom/Presentation/SignUp/SignUpContentView.swift
@@ -107,15 +107,20 @@ extension SignUpContentView {
       } label: {
         ButtonWDescriptionB(title: "개인정보 처리방침", subtitle: "확인하기", isActive: signUpViewModel.isCheckedPrivacyPolicy)
       }
-      .frame(maxWidth: .infinity)
       
       Button {
         showTermOfUse = true
       } label: {
         ButtonWDescriptionB(title: "서비스 이용약관", subtitle: "확인하기", isActive: signUpViewModel.isCheckedTermsOfuse)
       }
-      .frame(maxWidth: .infinity)
+      
+      Button {
+        signUpViewModel.isCheckedOverFourteen.toggle()
+      } label: {
+        ButtonWDescriptionB(title: "만 14세 이상입니다.", subtitle: "동의하기", isActive: signUpViewModel.isCheckedOverFourteen)
+      }
     }
+    .frame(maxWidth: .infinity)
     
     .sheet(isPresented: $showPrivacyPolicy, content: {
       EmbedWebView(viewTitle: "개인정보 처리방침", urlString: ServiceWebURL.privacyPolicy.rawValue, type: .sheet, showSheet: $showPrivacyPolicy, checkContract: $signUpViewModel.isCheckedPrivacyPolicy)

--- a/ABloom/ABloom/Presentation/SignUp/SignUpViewModel.swift
+++ b/ABloom/ABloom/Presentation/SignUp/SignUpViewModel.swift
@@ -16,6 +16,7 @@ final class SignUpViewModel: ObservableObject {
   @Published var inputName: String = ""
   @Published var isCheckedPrivacyPolicy = false
   @Published var isCheckedTermsOfuse = false
+  @Published var isCheckedOverFourteen = false
   
   @Published var isSuccessCreateUser = false
   
@@ -89,7 +90,7 @@ final class SignUpViewModel: ObservableObject {
     case .step3:
       self.inputName.isEmpty
     case .step4:
-      !self.isCheckedPrivacyPolicy || !self.isCheckedTermsOfuse
+      !self.isCheckedPrivacyPolicy || !self.isCheckedTermsOfuse || !self.isCheckedOverFourteen
     }
   }
   


### PR DESCRIPTION
(cherry picked from commit c9b5c2f7120b9daff1a808c24473ff38b3874dba)

#### close #328 

### ✏️ 개요
회원 가입 플로우에 만 14세 이상임을 확인하는 장치를 추가합니다.

### 💻 작업 사항
- [x] 만 14세 이상 동의 버튼 추가
- [x] 완료 버튼 disable 로직 수정 

### 📄 리뷰 노트
없씁니다

### 📱결과 화면(optional)
|  | |
|--------|--------|
| ![image](https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/100195563/130aa902-0032-4625-891b-7d1fce08b61e) | ![image](https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/100195563/3a697af8-fb46-46d8-bb76-7f63b4d286be) | 


