### PR TITLE
[Bug/#350] 문답완성필드로직수정

### DIFF
--- a/ABloom/ABloom/Presentation/Main/CheckAnswer/CheckAnswerViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/CheckAnswer/CheckAnswerViewModel.swift
@@ -223,15 +223,13 @@ final class CheckAnswerViewModel: ObservableObject {
     
     MixpanelManager.qnaReaction(type: selectedReactionType.reactionContent)
     
-    // 상대방의 반응이 없을 시 return
-    // is_complete Default 값은 false
-    guard let selectedFianceReactionType = fianceReactionStatus.reactionType else {return}
-    guard let fianceId = fianceUser?.userId else {return}
-    guard let fianceAnswerId = fianceAnswerId else {return}
+    // 문답 완성(is_complete)필드 업데이트
+    guard let fianceId = fianceUser?.userId else { return }
+    guard let fianceAnswerId = fianceAnswerId else { return}
     
-    let isCompleted = (selectedReactionType.isPositiveReact() && selectedFianceReactionType.isPositiveReact())
+    let isCompleted = (selectedReactionType.isPositiveReact() && checkFianceReaction())
     
     AnswerManager.shared.updateAnswerComplete(userId: currentUserId, answerId: currentUserAnswerId, status: isCompleted)
-    AnswerManager.shared.updateAnswerComplete(userId: fianceId, answerId: fianceAnswerId, status: isCompleted) 
+    AnswerManager.shared.updateAnswerComplete(userId: fianceId, answerId: fianceAnswerId, status: isCompleted)
   }
 }


### PR DESCRIPTION
#### close #350

### ✏️ 개요
- 처음부터 긍정-긍정 반응일 경우, 문답 완성 알림이 보내지지 않는 버그 수정
- is_complete 로직 처리 변경

### 💻 작업 사항
- selectedFianceReactionType.isPositiveReact() -> checkFianceReaction() 로 변경하여 상대방의 반응에 즉각 대응하도록 함
리액션이 null에서 값이 들어와 바뀔 때, selectedFianceReactionType 이 바뀐 값이 아닌 null을 return 하고 있었음
- 나의 반응에 대해서는 반대로 selectedReactionType 변수가 변경된 값을 지니고 있어서 그대로 유지 (checkMyReaction()은 기존 DB에 있는 이전 값을 불러옴)