### PR TITLE
[Feat/#354] 알림-DB 업데이트 로직 수정

### DIFF
--- a/ABloom/ABloom/Firebase/Firestore/AnswerManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/AnswerManager.swift
@@ -92,15 +92,13 @@ final class AnswerManager: ObservableObject {
   }
   
   // MARK: Update Reaction & Completion
-  func updateReactionNCompletion(userId: String, answerId: String, reaction: ReactionType?, isComplete: Bool?) {
+  func updateReactionNCompletion(userId: String, answerId: String, reaction: ReactionType?, isComplete: Bool) {
     var data: [String: Any] = [:]
+    
+    data[DBAnswer.CodingKeys.isComplete.rawValue] = isComplete
     
     if let reaction = reaction {
       data[DBAnswer.CodingKeys.reaction.rawValue] = reaction.rawValue
-    }
-    
-    if let isComplete = isComplete {
-      data[DBAnswer.CodingKeys.isComplete.rawValue] = isComplete
     }
     
     userAnswerCollection(userId: userId).document(answerId).updateData(data)

--- a/ABloom/ABloom/Firebase/Firestore/AnswerManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/AnswerManager.swift
@@ -91,12 +91,21 @@ final class AnswerManager: ObservableObject {
     }
   }
   
-  // MARK: Update
-  func updateReaction(userId: String, answerId: String, reaction: ReactionType) {
-    let data: [String: Any] = [DBAnswer.CodingKeys.reaction.rawValue:reaction.rawValue]
+  // MARK: Update Reaction & Completion
+  func updateReactionNCompletion(userId: String, answerId: String, reaction: ReactionType?, isComplete: Bool?) {
+    var data: [String: Any] = [:]
+    
+    if let reaction = reaction {
+      data[DBAnswer.CodingKeys.reaction.rawValue] = reaction.rawValue
+    }
+    
+    if let isComplete = isComplete {
+      data[DBAnswer.CodingKeys.isComplete.rawValue] = isComplete
+    }
     
     userAnswerCollection(userId: userId).document(answerId).updateData(data)
   }
+  
   
   // MARK: Disconnect
   func disconnectListener() {
@@ -106,10 +115,5 @@ final class AnswerManager: ObservableObject {
     self.fianceAnswers = []
   }
   
-  // MARK: Update Answer Completed
-  func updateAnswerComplete(userId: String, answerId: String, status: Bool) {
-    let data: [String: Any] = [DBAnswer.CodingKeys.isComplete.rawValue:status]
-    
-    userAnswerCollection(userId: userId).document(answerId).updateData(data)
-  }
+  
 }

--- a/ABloom/ABloom/Presentation/Main/CheckAnswer/CheckAnswerViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/CheckAnswer/CheckAnswerViewModel.swift
@@ -219,17 +219,17 @@ final class CheckAnswerViewModel: ObservableObject {
     guard let currentUserId = currentUser?.userId else { return }
     guard let currentUserAnswerId = currentUserAnswerId else { return }
     
-    AnswerManager.shared.updateReaction(userId: currentUserId, answerId: currentUserAnswerId, reaction: selectedReactionType)
-    
-    MixpanelManager.qnaReaction(type: selectedReactionType.reactionContent)
-    
     // 문답 완성(is_complete)필드 업데이트
     guard let fianceId = fianceUser?.userId else { return }
     guard let fianceAnswerId = fianceAnswerId else { return}
     
     let isCompleted = (selectedReactionType.isPositiveReact() && checkFianceReaction())
     
-    AnswerManager.shared.updateAnswerComplete(userId: currentUserId, answerId: currentUserAnswerId, status: isCompleted)
-    AnswerManager.shared.updateAnswerComplete(userId: fianceId, answerId: fianceAnswerId, status: isCompleted)
+    AnswerManager.shared.updateReactionNCompletion(userId: currentUserId, answerId: currentUserAnswerId, reaction: selectedReactionType, isComplete: isCompleted)
+    
+    AnswerManager.shared.updateReactionNCompletion(userId: fianceId, answerId: fianceAnswerId, reaction: nil, isComplete: isCompleted)
+    
+
+    MixpanelManager.qnaReaction(type: selectedReactionType.reactionContent)
   }
 }


### PR DESCRIPTION
#### close #354

### ✏️ 개요
- 리액션과 문답완성 필드가 각각 DB에 업데이트 됨에 따라 Firebase Function 반응이 2번 일어나서 한번에 긍정-긍정 반응이 될 경우, 리액션 알림과 문답완성 알림이 동시에 전송되는 버그 수정

### 💻 작업 사항
- JS 코드에서 함수 두개를 하나로 합침 => 테스트를 위해 수정한 후, 로직에는 문제가 없고 서버에 등록된 함수 갯수를 줄일 수 있어 그대로 유지
- AnswerManger에서 리액션과 is_complete 필드를 동시에 수정 및 업데이트 가능하도록 수정

### 📄 리뷰 노트
- 릴리즈 후 버그여서 우선 develop 브랜치를 base로 해두었습니다. 마이너 버그 수정으로 빠른 릴리즈해도 괜찮을 거 같고, 릴리즈 관련해서는 벤틀리, 제이와 상의가 필요합니다.

ps. 이번엔 진짜 알림 버그 완전 적용 되었다고 생각하긴 합니다만, 동시에 두 기기에서 테스트해야 하는 한계로 놓치는 부분이 계속 있었네요,, 
두 기기로 테스트하고 PR 날립니다,,