### PR TITLE
[Feat/#356] mixpanel 코드 삽입 및 수정, 구현

### DIFF
--- a/ABloom/ABloom/Firebase/ConnectionShare/KakaoShareManager.swift
+++ b/ABloom/ABloom/Firebase/ConnectionShare/KakaoShareManager.swift
@@ -25,6 +25,9 @@ final class KakaoShareManager: NSObject {
         }
         else {
           print("shareCustom() success.")
+          
+          MixpanelManager.connectKakao(code: code)
+          
           if let sharingResult = sharingResult {
             UIApplication.shared.open(sharingResult.url, options: [:], completionHandler: nil)
           }

--- a/ABloom/ABloom/Presentation/Main/CreateAnswer/WriteAnswer/WriteAnswerView.swift
+++ b/ABloom/ABloom/Presentation/Main/CreateAnswer/WriteAnswer/WriteAnswerView.swift
@@ -75,7 +75,7 @@ struct WriteAnswerView: View {
     .alert("답변을 완료할까요?", isPresented: $writeAMV.isCompleteAlertOn, actions: {
       Button {
         writeAMV.swipeEnable()
-        try? writeAMV.createAnswer(qid: question.questionID)
+        try? writeAMV.createAnswer(qid: question.questionID, category: question.category)
         isSheetOn.toggle()
       } label: {
         Text("완료하기")

--- a/ABloom/ABloom/Presentation/Main/CreateAnswer/WriteAnswer/WriteAnswerViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/CreateAnswer/WriteAnswer/WriteAnswerViewModel.swift
@@ -52,10 +52,10 @@ class WriteAnswerViewModel: ObservableObject {
     self.isCompleteAlertOn.toggle()
   }
   
-  func createAnswer(qid: Int) throws {
+  func createAnswer(qid: Int, category: String) throws {
     let uid = try AuthenticationManager.shared.getAuthenticatedUser().uid
     try AnswerManager.shared.createAnswer(userId: uid, questionId: qid, content: self.ansText)
-    MixpanelManager.qnaAnswer(letterCount: ansText.count)
+    MixpanelManager.qnaAnswer(letterCount: ansText.count, category: category, questionId: qid)
   }
   
 }

--- a/ABloom/ABloom/Resources/Utilities/MixpanelManager.swift
+++ b/ABloom/ABloom/Resources/Utilities/MixpanelManager.swift
@@ -138,3 +138,10 @@ extension MixpanelManager {
     instance.track(event: "connect_kakao", properties: properties)
   }
 }
+
+// MARK: Track Notification Event
+extension MixpanelManager {
+  static func recommendedQuestionNotification() {
+    instance.track(event: "recommended_question_notification")
+  }
+}

--- a/ABloom/ABloom/Resources/Utilities/MixpanelManager.swift
+++ b/ABloom/ABloom/Resources/Utilities/MixpanelManager.swift
@@ -126,4 +126,11 @@ extension MixpanelManager {
     instance.people.set(properties: properties)
     instance.track(event: "connect_complete", properties: properties)
   }
+  
+  static func connectKakao(code: String) {
+    let properties = ["Invitation Code":code]
+    
+    instance.people.set(properties: properties)
+    instance.track(event: "connect_kakao", properties: properties)
+  }
 }

--- a/ABloom/ABloom/Resources/Utilities/MixpanelManager.swift
+++ b/ABloom/ABloom/Resources/Utilities/MixpanelManager.swift
@@ -91,8 +91,12 @@ extension MixpanelManager {
     instance.track(event: "qna_select_question", properties: properties)
   }
   
-  static func qnaAnswer(letterCount: Int) {
-    let eventProperties = ["Letter Count": "\(letterCount)"]
+  static func qnaAnswer(letterCount: Int, category: String, questionId: Int) {
+    // 1. 카테고리
+    // 2. 질문의 번호
+    let eventProperties = ["Letter Count": "\(letterCount)",
+                           "Category": category,
+                           "Question ID": "\(questionId)"]
     
     instance.people.increment(property: "answeredQuestion", by: 1)
     instance.track(event: "qna_answer", properties: eventProperties)


### PR DESCRIPTION
#### close #356

### ✏️ 개요
유저 트래킹을 위한 믹스패널 코드를 삽입, 수정, 구현을 하였습니다.

### 💻 작업 사항
- 카카오톡 공유하기 기능 추적
- 답변 생성 프로퍼티 추가
- 알림 접근을 위한 메서드 작성

### 📄 리뷰 노트
알림 접근에 대한 로직을 잘 몰라 구현하지 못했습니다. 추후 리아와 함께 작업할 예정입니다.