### PR TITLE
[Feat/#367] 리뷰팝업추가

### DIFF
--- a/ABloom/ABloom/Presentation/Main/CreateAnswer/WriteAnswer/WriteAnswerView.swift
+++ b/ABloom/ABloom/Presentation/Main/CreateAnswer/WriteAnswer/WriteAnswerView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct WriteAnswerView: View {
   @Environment(\.dismiss) private var dismiss
-  @StateObject var writeAMV = WriteAnswerViewModel()
+  @StateObject var writeVM = WriteAnswerViewModel()
   @Binding var isSheetOn: Bool
   
   var question: DBStaticQuestion
@@ -31,7 +31,7 @@ struct WriteAnswerView: View {
     }
     .padding(.horizontal, 20)
     .ignoresSafeArea(.keyboard)
-    .interactiveDismissDisabled(writeAMV.ansText.isEmpty ? false : true)
+    .interactiveDismissDisabled(writeVM.ansText.isEmpty ? false : true)
     .onAppear(perform: UIApplication.shared.hideKeyboard)
     
     // 네비게이션바
@@ -39,26 +39,26 @@ struct WriteAnswerView: View {
       Text("답변 작성하기")
     } leftView: {
       Button(action: {
-        writeAMV.backClicked()
-        if !writeAMV.isCancelAlertOn {
+        writeVM.backClicked()
+        if !writeVM.isCancelAlertOn {
           dismiss()
         }
       }, label: {
         NavigationArrowLeft()
       })
     } rightView: {
-      Button(action: { writeAMV.completeClicked() }, label: {
+      Button(action: { writeVM.completeClicked() }, label: {
         Text("완료")
           .customFont(.calloutB)
-          .foregroundStyle((writeAMV.ansText.isEmpty || writeAMV.isTextOver) ? .gray400 : .primary80)
+          .foregroundStyle((writeVM.ansText.isEmpty || writeVM.isTextOver) ? .gray400 : .primary80)
       })
-      .disabled(writeAMV.ansText.isEmpty || writeAMV.isTextOver)
+      .disabled(writeVM.ansText.isEmpty || writeVM.isTextOver)
     }
     
     // 백버튼 알림
-    .alert("작성을 종료할까요?", isPresented: $writeAMV.isCancelAlertOn, actions: {
+    .alert("작성을 종료할까요?", isPresented: $writeVM.isCancelAlertOn, actions: {
       Button {
-        writeAMV.swipeEnable()
+        writeVM.swipeEnable()
         dismiss()
       } label: {
         Text("나가기")
@@ -72,11 +72,11 @@ struct WriteAnswerView: View {
     
     
     // 완료 알림
-    .alert("답변을 완료할까요?", isPresented: $writeAMV.isCompleteAlertOn, actions: {
+    .alert("답변을 완료할까요?", isPresented: $writeVM.isCompleteAlertOn, actions: {
       Button {
-        writeAMV.swipeEnable()
-        try? writeAMV.createAnswer(qid: question.questionID, category: question.category)
-        writeAMV.observeAnswerCount()
+        writeVM.swipeEnable()
+        try? writeVM.createAnswer(qid: question.questionID, category: question.category)
+        writeVM.observeAnswerCount()
         isSheetOn.toggle()
       } label: {
         Text("완료하기")
@@ -101,10 +101,10 @@ extension WriteAnswerView {
   
   private var textField: some View {
     
-    TextEditor(text: $writeAMV.ansText)
-      .opacity(writeAMV.ansText.isEmpty ? 0.2 : 1.0)
+    TextEditor(text: $writeVM.ansText)
+      .opacity(writeVM.ansText.isEmpty ? 0.2 : 1.0)
       .background(alignment: .topLeading) {
-        TextEditor(text: .constant(writeAMV.ansText.isEmpty ? "내 답변을 작성해보세요..." : ""))
+        TextEditor(text: .constant(writeVM.ansText.isEmpty ? "내 답변을 작성해보세요..." : ""))
           .foregroundStyle(.gray500)
       }
       .foregroundStyle(.gray500)
@@ -113,17 +113,17 @@ extension WriteAnswerView {
       .multilineTextAlignment(.leading)
       .frame(maxWidth: .infinity)
       .frame(maxHeight: UIScreen.main.bounds.size.height/3.5 - 10) 
-      .onChange(of: writeAMV.ansText, perform: { new in
-        writeAMV.checkTextCount()
+      .onChange(of: writeVM.ansText, perform: { new in
+        writeVM.checkTextCount()
       })
   }
   
   private var textNumCheck: some View {
     HStack(spacing: 0) {
       Spacer()
-      Text("\(writeAMV.ansText.count)")
+      Text("\(writeVM.ansText.count)")
         .customFont(.footnoteR)
-        .foregroundStyle( writeAMV.isTextOver ? .red : .gray400)
+        .foregroundStyle( writeVM.isTextOver ? .red : .gray400)
       
       Text(" / 150")
         .customFont(.footnoteR)

--- a/ABloom/ABloom/Presentation/Main/CreateAnswer/WriteAnswer/WriteAnswerView.swift
+++ b/ABloom/ABloom/Presentation/Main/CreateAnswer/WriteAnswer/WriteAnswerView.swift
@@ -76,6 +76,7 @@ struct WriteAnswerView: View {
       Button {
         writeAMV.swipeEnable()
         try? writeAMV.createAnswer(qid: question.questionID, category: question.category)
+        writeAMV.observeAnswerCount()
         isSheetOn.toggle()
       } label: {
         Text("완료하기")

--- a/ABloom/ABloom/Presentation/Main/CreateAnswer/WriteAnswer/WriteAnswerView.swift
+++ b/ABloom/ABloom/Presentation/Main/CreateAnswer/WriteAnswer/WriteAnswerView.swift
@@ -76,7 +76,6 @@ struct WriteAnswerView: View {
       Button {
         writeVM.swipeEnable()
         try? writeVM.createAnswer(qid: question.questionID, category: question.category)
-        writeVM.observeAnswerCount()
         isSheetOn.toggle()
       } label: {
         Text("완료하기")

--- a/ABloom/ABloom/Presentation/Main/CreateAnswer/WriteAnswer/WriteAnswerViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/CreateAnswer/WriteAnswer/WriteAnswerViewModel.swift
@@ -4,8 +4,11 @@
 //
 //  Created by yun on 11/20/23.
 //
-
+import Combine
+import Foundation
+import StoreKit
 import SwiftUI
+
 
 @MainActor
 class WriteAnswerViewModel: ObservableObject {
@@ -13,6 +16,14 @@ class WriteAnswerViewModel: ObservableObject {
   @Published var isCompleteAlertOn = Bool()
   @Published var ansText: String = ""
   @Published var isTextOver = Bool()
+  
+  private var cancellables = Set<AnyCancellable>()
+    
+  private func requestReview() {
+    if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+      SKStoreReviewController.requestReview(in: scene)
+    }
+  }
   
   func checkTextCount() {
     // 맥시멈 제한
@@ -56,6 +67,24 @@ class WriteAnswerViewModel: ObservableObject {
     let uid = try AuthenticationManager.shared.getAuthenticatedUser().uid
     try AnswerManager.shared.createAnswer(userId: uid, questionId: qid, content: self.ansText)
     MixpanelManager.qnaAnswer(letterCount: ansText.count, category: category, questionId: qid)
+  }
+  
+  // MARK: - ReviewPopUp 관련
+  
+  // '나'가 작성한 문답 갯수 카운트
+  func observeAnswerCount() {
+    AnswerManager.shared.$myAnswers
+      .sink { [weak self] myAnswers in
+        let totalCount = myAnswers?.count ?? 0
+        self?.checkReviewRequest(totalCount: totalCount)
+      }
+      .store(in: &cancellables)
+  }
+  
+  private func checkReviewRequest(totalCount: Int) {
+    if totalCount == 5 || totalCount == 20 || totalCount == 50 {
+      requestReview()
+    }
   }
   
 }

--- a/ABloom/ABloom/Presentation/Main/CreateAnswer/WriteAnswer/WriteAnswerViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/CreateAnswer/WriteAnswer/WriteAnswerViewModel.swift
@@ -4,9 +4,6 @@
 //
 //  Created by yun on 11/20/23.
 //
-import Combine
-import Foundation
-import StoreKit
 import SwiftUI
 
 
@@ -17,13 +14,6 @@ class WriteAnswerViewModel: ObservableObject {
   @Published var ansText: String = ""
   @Published var isTextOver = Bool()
   
-  private var cancellables = Set<AnyCancellable>()
-    
-  private func requestReview() {
-    if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
-      SKStoreReviewController.requestReview(in: scene)
-    }
-  }
   
   func checkTextCount() {
     // 맥시멈 제한
@@ -68,23 +58,4 @@ class WriteAnswerViewModel: ObservableObject {
     try AnswerManager.shared.createAnswer(userId: uid, questionId: qid, content: self.ansText)
     MixpanelManager.qnaAnswer(letterCount: ansText.count, category: category, questionId: qid)
   }
-  
-  // MARK: - ReviewPopUp 관련
-  
-  // '나'가 작성한 문답 갯수 카운트
-  func observeAnswerCount() {
-    AnswerManager.shared.$myAnswers
-      .sink { [weak self] myAnswers in
-        let totalCount = myAnswers?.count ?? 0
-        self?.checkReviewRequest(totalCount: totalCount)
-      }
-      .store(in: &cancellables)
-  }
-  
-  private func checkReviewRequest(totalCount: Int) {
-    if totalCount == 5 || totalCount == 20 || totalCount == 50 {
-      requestReview()
-    }
-  }
-  
 }

--- a/ABloom/ABloom/Presentation/Main/QnAList/QnAListViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/QnAList/QnAListViewModel.swift
@@ -175,7 +175,7 @@ final class QnAListViewModel: ObservableObject {
   }
   
   private func checkReviewRequest(totalCount: Int) {
-    if totalCount == 22 || totalCount == 20 || totalCount == 50 {
+    if totalCount == 5 || totalCount == 20 || totalCount == 50 {
       requestReview()
     }
   }

--- a/ABloom/ABloom/Presentation/Main/QnAList/QnAListViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/QnAList/QnAListViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import StoreKit
 import SwiftUI
 
 enum QnAListViewState {
@@ -25,7 +26,14 @@ final class QnAListViewModel: ObservableObject {
   
   @Published var currentUser: DBUser?
   
-  @Published var currentUserAnswers: [DBAnswer]?
+  @Published var currentUserAnswers: [DBAnswer]? {
+    didSet {
+      myAnswerCount = currentUserAnswers?.count ?? 0
+      checkReviewRequest(totalCount: myAnswerCount)
+    }
+  }
+  @Published var myAnswerCount: Int = 0
+  
   @Published var fianceAnswers: [DBAnswer]?
   @Published var coupleQnA = [CouplueQnA]()
     
@@ -158,6 +166,21 @@ final class QnAListViewModel: ObservableObject {
       viewState = .isSorted
     }
   }
+  // MARK: - 리뷰팝업 함수
+  
+  private func requestReview() {
+    if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+      SKStoreReviewController.requestReview(in: scene)
+    }
+  }
+  
+  private func checkReviewRequest(totalCount: Int) {
+    if totalCount == 22 || totalCount == 20 || totalCount == 50 {
+      requestReview()
+    }
+  }
+  
+  // MARK: - 상태확인
   
   func checkAnswerStatus(question: DBStaticQuestion) -> AnswerStatus {
     guard let idx = coupleQnA.firstIndex(where: { $0.question == question }) else { return .error }


### PR DESCRIPTION
#### close #367

### ✏️ 개요
리뷰팝업로직 추가
'나'가 작성한 문답이 5개, 20개, 50개가 될 경우 리뷰 팝업

### 💻 작업 사항
- StoreKit 활용하여 default 뷰 사용 => StoreKit의 경우 뷰 수정이 불가
- Firebase snapshot sink로 갯수 불러오기
- AnswerWriteViewModel에 로직 추가


### 📄 리뷰 노트
[문답갯수 관련]
UserDefault로 로컬에서 저장해도 되는데, 혹여나 다른 기기로 계정에 로그인할 경우 정보되지 않아 sink로 실시간 정보 받아오는 방식 채택

[AnswerWriteViewModel 수정이유]
메인뷰에서 1)기존 getMyAnswer 함수 내에서 갯수 확인을 추가로 하거나 2)지금 구현한 함수 그대로 구현하고자 했으나
1)의 경우 다른 기능 구현 함수여서 분리하는게 맞다고 판단함
2)의 경우 AnswerWriteView에서 뷰가 팝 되는 방식이어서 팝되고 시간 지연 후에 리뷰팝업이 나오는 현상이 있었음
현재는 팝 되기전에 함수를 실행시키고 팝 되고 나서 잠시 후 리뷰팝업이 올라옴

### 📱결과 화면(optional)
<img src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/44897331/90ff023b-fbc8-462b-8015-cba6bf235c57" width="300" height="700">

### 📚 ETC(optional)
StoreKit 활용으로 1년에 리뷰팝업이 3개로 제한된다고 합니다. 로직상으로 구현 자체는 가능하지만, 시스템 내부에서 365일 내로 3번 팝업이 된 경우에는 더이상 팝업되지 않도록 막도록 되어 있습니다. 이에, 기획측에서 5,20,50 숫자를 제시해서 이를 적용한 상태입니다.