### PR TITLE
[Bug/#373] 로그인 후 바로 문답 생성시 화면에 바로 보여지지 않는 버그 픽스

### DIFF
--- a/ABloom/ABloom/Firebase/Firestore/UserManager.swift
+++ b/ABloom/ABloom/Firebase/Firestore/UserManager.swift
@@ -116,7 +116,6 @@ final class UserManager: ObservableObject {
     try await connectionUpdate(userId: currentUser.userId, targetId: targetUserId)
     try await fetchCurrentUser()
     try await fetchFianceUser()
-    AnswerManager.shared.addSnapshotListenerForMyAnswer()
     AnswerManager.shared.addSnapshotListenerForFianceAnswer()
   }
   

--- a/ABloom/ABloom/Presentation/Main/QnAList/QnAListViewModel.swift
+++ b/ABloom/ABloom/Presentation/Main/QnAList/QnAListViewModel.swift
@@ -52,6 +52,7 @@ final class QnAListViewModel: ObservableObject {
     try? await UserManager.shared.fetchFianceUser()
     viewState = .isProgress
     fetchData()
+    AnswerManager.shared.addSnapshotListenerForMyAnswer()
   }
   
   private func getCurrentUser() {


### PR DESCRIPTION
#### close #373 

### ✏️ 개요
로그인 후 바로 문답 생성시 화면에 바로 보여지지 않는 문제가 있어, 스냅샷리스너를 적용하는 부분을 추가하여 해결하였습니다.
로그인 한 경우에 바로 사용자의 문답에 스냅샷을 적용함에 따라, 로그인 후 바로 Connect하는 경우에는 스냅샷이 중복되어 제거하였습니다.

### 💻 작업 사항
- [x] 문답리스트뷰모델의 fetchDataAfterSignIn 메서드에 "사용자문답 스냡샷 리스너" 추가
- [x] UserManager의 connectFiance에는 "사용자문답 스냡샷 리스너" 제거

### 📄 리뷰 노트
없습니다.

### 📱결과 화면(optional)
기존 버그 영상은 #373  에서 확인할 수 있습니다. 
로그인 후 "행복한 결혼 생활을 위해서~~" 질문에 대한 답변 생성하면, 상단에 뜨는 것을 확인할 수 있습니다. 

https://github.com/DeveloperAcademy-POSTECH/MacC-Team16-ABloom/assets/100195563/11a3ecd5-a24b-487b-b32a-7bf81955b501